### PR TITLE
explore-card: adjust difficulty colors for light mode

### DIFF
--- a/src/components/explore/difficulty-badge.tsx
+++ b/src/components/explore/difficulty-badge.tsx
@@ -6,11 +6,11 @@ interface Props {
 }
 
 const COLORS_BY_DIFFICULTY = {
-  BEGINNER: 'bg-pink-300',
-  EASY: 'bg-green-300',
-  MEDIUM: 'bg-yellow-300',
-  HARD: 'bg-red-300',
-  EXTREME: 'bg-orange-300',
+  BEGINNER: 'bg-pink-500 dark:bg-pink-300',
+  EASY: 'bg-green-500 dark:bg-green-300',
+  MEDIUM: 'bg-yellow-500 dark:bg-yellow-300',
+  HARD: 'bg-red-500 dark:bg-red-300',
+  EXTREME: 'bg-orange-500 dark:bg-orange-300',
 };
 export function DifficultyBadge({ difficulty }: Props) {
   return (

--- a/src/components/explore/explore-card.tsx
+++ b/src/components/explore/explore-card.tsx
@@ -9,11 +9,11 @@ interface Props {
 }
 
 const BORDERS_BY_DIFFICULTY = {
-  BEGINNER: 'hover:border-pink-300',
-  EASY: 'hover:border-green-300',
-  MEDIUM: 'hover:border-yellow-300',
-  HARD: 'hover:border-red-300',
-  EXTREME: 'hover:border-orange-300',
+  BEGINNER: 'dark:hover:border-pink-300 hover:border-pink-500',
+  EASY: 'dark:hover:border-green-300 hover:border-green-500',
+  MEDIUM: 'dark:hover:border-yellow-300 hover:border-yellow-500',
+  HARD: 'dark:hover:border-red-300 hover:border-red-500',
+  EXTREME: 'dark:hover:border-orange-300 hover:border-orange-500',
 };
 
 export function ExploreCard({ challenge }: Props) {


### PR DESCRIPTION
<img width="1317" alt="Screenshot 2023-06-30 at 5 12 24 PM" src="https://github.com/bautistaaa/typehero/assets/31113245/58438018-4c86-48ce-9376-021115e77cf3">
<img width="1330" alt="Screenshot 2023-06-30 at 5 12 34 PM" src="https://github.com/bautistaaa/typehero/assets/31113245/d20c8fcb-5456-46ce-94af-1d5088d87d0b">
