### PR TITLE
Fix imports to use aliases and add import eslint plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,8 +4,20 @@
 const config = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
-  extends: ['next/core-web-vitals', 'plugin:@typescript-eslint/recommended'],
+  extends: [
+    'next/core-web-vitals',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+  ],
   rules: {
+    // This is to enforce the use of import aliases
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['^(?!\\.\\/)((?!.)[sS])*) ?$', '../.*'],
+      },
+    ],
     '@typescript-eslint/consistent-type-imports': [
       'warn',
       {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "autoprefixer": "^10.4.14",
     "eslint": "^8.40.0",
     "eslint-config-next": "^13.4.2",
+    "eslint-plugin-import": "^2.27.5",
     "husky": "^8.0.0",
     "lint-staged": "^13.2.3",
     "postcss": "^8.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ devDependencies:
   eslint-config-next:
     specifier: ^13.4.2
     version: 13.4.2(eslint@8.40.0)(typescript@5.1.3)
+  eslint-plugin-import:
+    specifier: ^2.27.5
+    version: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.40.0)
   husky:
     specifier: ^8.0.0
     version: 8.0.0

--- a/src/app/challenge/[id]/getChallengeRouteData.ts
+++ b/src/app/challenge/[id]/getChallengeRouteData.ts
@@ -1,6 +1,6 @@
 'use server';
 import { type Session } from 'next-auth';
-import { prisma } from '../../../server/db';
+import { prisma } from '~/server/db';
 
 export type ChallengeRouteData = NonNullable<Awaited<ReturnType<typeof getChallengeRouteData>>>;
 

--- a/src/app/challenge/[id]/solutions/[solutionId]/page.tsx
+++ b/src/app/challenge/[id]/solutions/[solutionId]/page.tsx
@@ -1,21 +1,9 @@
-import { notFound } from 'next/navigation';
-import { getServerAuthSession } from '../../../../../server/auth';
-import { getChallengeRouteData } from '../../getChallengeRouteData';
-
 interface Props {
   params: {
-    id: string;
     solutionId: string;
   };
 }
 
-export default async function SolutionPage({ params: { id, solutionId } }: Props) {
-  // const session = await getServerAuthSession();
-  // const challenge = await getChallengeRouteData(id, session);
-  //
-  // if (!challenge) {
-  //   return notFound();
-  // }
-  //
+export default async function SolutionPage({ params: { solutionId } }: Props) {
   return <div>some details go here for {solutionId}</div>;
 }

--- a/src/app/challenge/[id]/solutions/page.tsx
+++ b/src/app/challenge/[id]/solutions/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { getChallengeRouteData } from '../getChallengeRouteData';
-import { getServerAuthSession } from '../../../../server/auth';
+import { getServerAuthSession } from '~/server/auth';
 import { Solutions } from '~/components/challenge/solutions';
 
 interface Props {

--- a/src/app/challenge/[id]/submissions/[submissionId]/page.tsx
+++ b/src/app/challenge/[id]/submissions/[submissionId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
-import { getServerAuthSession } from '../../../../../server/auth';
-import { getChallengeRouteData } from '../../getChallengeRouteData';
+import { getServerAuthSession } from '~/server/auth';
+
+import { getChallengeRouteData } from '~/app/challenge/[id]/getChallengeRouteData';
 import { Submissions } from '~/components/challenge/submissions';
 interface Props {
   params: {

--- a/src/app/challenge/[id]/submissions/page.tsx
+++ b/src/app/challenge/[id]/submissions/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { Submissions } from '~/components/challenge/submissions';
-import { getServerAuthSession } from '../../../../server/auth';
+import { getServerAuthSession } from '~/server/auth';
 import { getChallengeRouteData } from '../getChallengeRouteData';
 
 interface Props {

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -13,7 +13,7 @@ import { ToastAction } from '@radix-ui/react-toast';
 import { useRouter } from 'next/navigation';
 
 import { type Difficulty } from '@prisma/client';
-import ExploreCardInputs from '../../components/create/explore-card-inputs';
+import ExploreCardInputs from '~/components/create/explore-card-inputs';
 
 import { useTheme } from 'next-themes';
 

--- a/src/app/create/preview/page.tsx
+++ b/src/app/create/preview/page.tsx
@@ -5,9 +5,9 @@ import { useCreateChallengeStore } from '../create-challenge-store';
 import { useRouter } from 'next/navigation';
 import { CodePanel } from '~/components/challenge/editor';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import { Markdown } from '../../../components/ui/markdown';
-import ExploreCard from '../../../components/explore/explore-card';
-import { Button } from '../../../components/ui/button';
+import { Markdown } from '~/components/ui/markdown';
+import ExploreCard from '~/components/explore/explore-card';
+import { Button } from '~/components/ui/button';
 
 export default function PreviewCreatedChallenge() {
   const createChallengeStore = useCreateChallengeStore();

--- a/src/components/challenge/comments/comment.tsx
+++ b/src/components/challenge/comments/comment.tsx
@@ -7,12 +7,12 @@ import { z } from 'zod';
 import type { ChallengeRouteData } from '~/app/challenge/[id]/getChallengeRouteData';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog';
 import { getRelativeTime } from '~/utils/relativeTime';
-import { Button } from '../../ui/button';
-import { Checkbox } from '../../ui/checkbox';
-import { Form, FormField, FormItem } from '../../ui/form';
-import { Textarea } from '../../ui/textarea';
-import { TypographyLarge } from '../../ui/typography/large';
-import { toast } from '../../ui/use-toast';
+import { Button } from '~/components/ui/button';
+import { Checkbox } from '~/components/ui/checkbox';
+import { Form, FormField, FormItem } from '~/components/ui/form';
+import { Textarea } from '~/components/ui/textarea';
+import { TypographyLarge } from '~/components/ui/typography/large';
+import { toast } from '~/components/ui/use-toast';
 import { reportChallengeComment } from './comment.action';
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip';
 

--- a/src/components/challenge/comments/index.tsx
+++ b/src/components/challenge/comments/index.tsx
@@ -6,7 +6,7 @@ import { type ChallengeRouteData } from '~/app/challenge/[id]/getChallengeRouteD
 import Comment from '~/components/challenge/comments/comment';
 import { Button } from '~/components/ui/button';
 import { toast } from '~/components/ui/use-toast';
-import { Input } from '../../ui/input';
+import { Input } from '~/components/ui/input';
 import NoComments from '../nocomments';
 import { addChallengeComment } from './comment.action';
 

--- a/src/components/challenge/description/index.tsx
+++ b/src/components/challenge/description/index.tsx
@@ -22,17 +22,17 @@ import {
 } from '~/components/ui/dialog';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/components/ui/tooltip';
 import { TypographyH3 } from '~/components/ui/typography/h3';
-import { DifficultyBadge } from '../../explore/difficulty-badge';
-import { ActionMenu } from '../../ui/action-menu';
-import { Checkbox } from '../../ui/checkbox';
-import { Form, FormField, FormItem } from '../../ui/form';
-import { Markdown } from '../../ui/markdown';
-import { Textarea } from '../../ui/textarea';
-import { TypographyLarge } from '../../ui/typography/large';
+import { DifficultyBadge } from '~/components/explore/difficulty-badge';
+import { ActionMenu } from '~/components/ui/action-menu';
+import { Checkbox } from '~/components/ui/checkbox';
+import { Form, FormField, FormItem } from '~/components/ui/form';
+import { Markdown } from '~/components/ui/markdown';
+import { Textarea } from '~/components/ui/textarea';
+import { TypographyLarge } from '~/components/ui/typography/large';
 import { ShareForm } from '../share-form';
 
 import { type ChallengeRouteData } from '~/app/challenge/[id]/getChallengeRouteData';
-import { toast } from '../../ui/use-toast';
+import { toast } from '~/components/ui/use-toast';
 import { addOrRemoveBookmark } from '../bookmark.action';
 import { incrementOrDecrementUpvote } from '../increment.action';
 import { addChallengeReport } from '../report.action';

--- a/src/components/challenge/share-form.tsx
+++ b/src/components/challenge/share-form.tsx
@@ -2,8 +2,6 @@
 
 import { useCallback, useState } from 'react';
 import { Clipboard as ClipboardIcon, CheckCircle2 as CheckCircle2Icon } from 'lucide-react';
-import { Button } from '../ui/button';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { DialogFooter } from '../ui/dialog';
 
 export function ShareForm() {

--- a/src/components/challenge/solutions/index.tsx
+++ b/src/components/challenge/solutions/index.tsx
@@ -42,7 +42,7 @@ export function Solutions({ challenge }: Props) {
             <SolutionRow
               key={solution.id}
               solution={solution}
-              handleClick={(id: string) => {
+              handleClick={() => {
                 setView('details');
               }}
             />
@@ -56,7 +56,6 @@ export function Solutions({ challenge }: Props) {
 }
 
 function SolutionRow({
-  handleClick,
   solution,
 }: {
   handleClick: (id: string) => void;

--- a/src/components/create/explore-card-inputs.tsx
+++ b/src/components/create/explore-card-inputs.tsx
@@ -7,7 +7,7 @@ import { DifficultyBadge } from '../explore/difficulty-badge';
 import { Markdown } from '../ui/markdown';
 import { getRelativeTime } from '~/utils/relativeTime';
 
-import { Select, SelectContent, SelectItem, SelectTrigger } from '../../components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '~/components/ui/select';
 import { Checkbox } from '~/components/ui/checkbox';
 import { Label } from '~/components/ui/label';
 

--- a/src/components/explore/difficulty-badge.tsx
+++ b/src/components/explore/difficulty-badge.tsx
@@ -12,6 +12,8 @@ const COLORS_BY_DIFFICULTY = {
   HARD: 'dark:bg-red-300 bg-red-500',
   EXTREME: 'dark:bg-orange-300 bg-orange-500',
 };
+
+// TODO: move this somewhere else
 export function DifficultyBadge({ difficulty }: Props) {
   return <Badge className={`${COLORS_BY_DIFFICULTY[difficulty]}`}>{difficulty}</Badge>;
 }

--- a/src/components/ui/action-menu.tsx
+++ b/src/components/ui/action-menu.tsx
@@ -1,4 +1,6 @@
+/* eslint-disable import/namespace */
 'use client';
+
 import React from 'react';
 import {
   DropdownMenu,

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/namespace */
 'use client';
 
 import * as AllIcons from 'lucide-react';

--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { LogIn, Plus, Settings, User, Bell, Moon, Sun, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { signIn, signOut } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 import { navigationMenuTriggerStyle } from './navigation-menu';
 import { Button } from './button';
 import {
@@ -16,7 +16,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './dropdown-menu';
-import { useSession } from 'next-auth/react';
 import { RoleTypes } from '@prisma/client';
 import { isProd } from '~/utils/featureFlags';
 


### PR DESCRIPTION
Closes #187

This PR also fixes all the lint warnings as well, this shouldn't break anything as I did some light testing.

Now you cannot import something with with traversed URLS above a single level and you must use the aliases instead.

Bad 🛑
![image](https://github.com/bautistaaa/typehero/assets/996134/ee66abd7-95c7-4a7c-9c98-4e67d7162b0d)

Good ✅
![image](https://github.com/bautistaaa/typehero/assets/996134/de397d2b-62e4-4783-bc3e-48ee9e36105b)