### PR TITLE
fix 404 pages in vercel deployment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,8 +3,7 @@
  * for Docker builds.
  */
 await import('./src/env.mjs');
-await import('./scripts/dl-monaco.mjs').then(({ download }) => download(true));
-
+await import('./scripts/dl-monaco.mjs').then(({ download }) => download());
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,


### PR DESCRIPTION
removing unused i18n config from `next.config.mjs` fixes domain prefix assignment on vercel deployments