### PR TITLE
Fix container name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '3'
 services:
   db:
     image: bitnami/mysql:latest
-    container_name: db
+    container_name: typehero-db
     restart: always
     environment:
       MYSQL_ROOT_USER: dev


### PR DESCRIPTION
Don't want it to take the "db" name spaces in my docker, added prefix.

![image](https://github.com/bautistaaa/typehero/assets/996134/6b95d48b-0040-4879-8339-987779a7aed1)
