### PR TITLE
Shareable Comments UI

### DIFF
--- a/src/components/challenge/comments/comment.tsx
+++ b/src/components/challenge/comments/comment.tsx
@@ -18,7 +18,6 @@ import { reportChallengeComment } from './comment.action';
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip';
 import { UserBadge } from '~/components/ui/user-badge';
 import { useSession } from 'next-auth/react';
-// import { Markdown } from '~/components/ui/markdown';
 
 interface CommentProps {
   comment: ChallengeRouteData['comment'][number];
@@ -134,25 +133,25 @@ const Comment = ({ comment }: CommentProps) => {
             </TooltipContent>
           </Tooltip>
         </div>
-    
+
         <div className="flex items-center gap-2">
           <div
             onClick={() => {
               copyPathNotifyUser();
             }}
-            className="mr-2 flex items-center text-neutral-500 hover:text-[#007bcd]"
+            className=" flex items-center text-neutral-500 hover:text-neutral-400"
           >
-            <Share className="h-3 w-3" />
+            <Share className="h-3 w-3 mr-0.5" />
             <small className="font-md text-sm leading-none hover:underline">Share</small>
           </div>
           {/* TODO: make dis work */}
-          <button className="flex cursor-pointer items-center gap-1 text-sm text-neutral-400 duration-200 hover:text-neutral-500 hover:underline dark:text-neutral-600 dark:hover:text-neutral-500">
+          <button className="flex cursor-pointer items-center gap-1 text-sm text-neutral-500 duration-200 hover:text-neutral-400 hover:underline dark:text-neutral-500 dark:hover:text-neutral-400">
             <Reply className="h-3 w-3" />
             Reply
           </button>
           {/* TODO: make dis work */}
           {isAuthor ? (
-            <button className="flex cursor-pointer items-center gap-1 text-sm text-neutral-400 duration-200 hover:text-neutral-500 hover:underline dark:text-neutral-600 dark:hover:text-neutral-500">
+            <button className="flex cursor-pointer items-center gap-1 text-sm text-neutral-500 duration-200 hover:text-neutral-400 hover:underline dark:text-neutral-500 dark:hover:text-neutral-400">
               <Trash2 className="h-3 w-3" />
               Delete
             </button>


### PR DESCRIPTION
A share button has been added to beside the report button (as per @PickleNik). 
![Screen Shot 2023-07-15 at 19 24 34 PM](https://github.com/bautistaaa/typehero/assets/101987676/5c67712e-e948-4f5d-835c-44dbc4219dac)

When the user clicks the share button, the comments URL is copied to the user's clipboard, and a toast notification is shown to the user indicating that this has happened.
![Screen Shot 2023-07-15 at 19 25 44 PM](https://github.com/bautistaaa/typehero/assets/101987676/3e92af5b-9356-4214-818c-01b0e0063a54)
