### PR TITLE
Remove scrolly bits from hero

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -33,7 +33,7 @@ const TypeHeroLogo = () => {
 };
 
 const Hero = () => (
-  <section className="lg:overflow-x-hidden">
+  <section className="overflow-hidden">
     {/* <svg className="pointer-events-none mix-blend-soft-light opacity-50 z-10 absolute left-0 top-0 h-full w-full" id="grain">
     <filter id="noise">
       <feTurbulence type="fractalNoise" baseFrequency="1" numOctaves="5" stitchTiles="stitch"></feTurbulence>


### PR DESCRIPTION
Turns out the scrolling bits from the hero were not only on Firefox, but were caused by certain screen dimensions. Setting the `overflow: hidden` on the element normalizes it.

![Screenshot from 2023-07-20 18-50-37](https://github.com/bautistaaa/typehero/assets/55156145/223964ea-2d51-4616-af95-b0c669772e28)
