### PR TITLE
tiny change on radii of styled buttons

### DIFF
--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -66,7 +66,7 @@ const Hero = () => (
             asChild
           >
             <Link href="/waitlist">
-              <span className="inline-flex h-full w-fit items-center gap-1 rounded-xl bg-white px-4 py-2 text-[#3178c6] transition-all duration-300">
+              <span className="inline-flex h-full w-fit items-center gap-1 rounded-[10px] bg-white px-4 py-2 text-[#3178c6] transition-all duration-300">
                 <Mail className="mr-1 h-4 w-4 stroke-[3]" />
                 Join the Waitlist
               </span>

--- a/src/components/landing/waitlist/banner.tsx
+++ b/src/components/landing/waitlist/banner.tsx
@@ -19,7 +19,8 @@ const Waitlist = () => {
             <Balancer>
               We’re currently working hard to make TypeHero the perfect place for TypeScript
               enthusiasts and learners. If you believe TypeHero can help you become a better
-              TypeScript developer in the future, consider joining our waitlist to get updates on our progress.
+              TypeScript developer in the future, consider joining our waitlist to get updates on
+              our progress.
             </Balancer>
           </p>
         </div>
@@ -28,7 +29,7 @@ const Waitlist = () => {
           asChild
         >
           <Link href="/waitlist">
-            <span className="inline-flex h-full w-fit items-center gap-1 rounded-xl bg-white/90 px-4 py-2 text-black transition-all duration-300 group-hover:rounded-3xl group-hover:bg-white/0 group-hover:text-white dark:bg-black/80 dark:text-white group-hover:dark:bg-black/0 dark:group-hover:text-black">
+            <span className="inline-flex h-full w-fit items-center gap-1 rounded-[10px] bg-white/90 px-4 py-2 text-black transition-all duration-300 group-hover:rounded-3xl group-hover:bg-white/0 group-hover:text-white dark:bg-black/80 dark:text-white group-hover:dark:bg-black/0 dark:group-hover:text-black">
               <Mail className="mr-1 h-4 w-4 stroke-[3]" />
               Join the Waitlist
             </span>


### PR DESCRIPTION
tiny, almost dismissable fix for the radii on some styled buttons of the landing that had inconsistent nested radii that caused this funky border dimension on the corners

Wonky:
![image](https://github.com/bautistaaa/typehero/assets/55156145/9cd25d49-3836-4a89-9e07-e521c86efcaa)

Not wonky:
![image](https://github.com/bautistaaa/typehero/assets/55156145/b553ec98-b2f6-4008-9931-0b2dfe866f5d)
