### PR TITLE
fix: redirects on auth actions

### DIFF
--- a/src/components/ui/navigation.tsx
+++ b/src/components/ui/navigation.tsx
@@ -131,7 +131,6 @@ function LoginButton() {
   };
   const handleSignOut = async () => {
     await signOut({ redirect: false });
-    router.push('/');
   };
 
   return session ? (

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -27,6 +27,11 @@ declare module 'next-auth' {
 
 export const authOptions: NextAuthOptions = {
   callbacks: {
+    redirect: async ({ url, baseUrl }) => {
+      if (url.startsWith('/')) return `${baseUrl}${url}`;
+      else if (new URL(url).origin === baseUrl) return url;
+      return baseUrl;
+    },
     session: async ({ session, user }) => {
       // 1. State
       let userRoles: RoleTypes[] = [];


### PR DESCRIPTION
- Fixes #280

- No longer redirects users to homepage on login;
- No longer redirects users to homepage on logout;

Keep in mind that logging in will still cause a full page reload because of how the callback endpoint from NextAuth does session handling. It seems the only way to prevent that is to explicitly override the callback handler with our own endpoint implementation to handle GItHub's callback.

