### PR TITLE
chore: refactor user queries to prevent user info leak

### DIFF
--- a/apps/admin/src/app/_components/admin.actions.tsx
+++ b/apps/admin/src/app/_components/admin.actions.tsx
@@ -1,8 +1,8 @@
 'use server';
 
-import { type Report, type Prisma } from '@repo/db/types';
-import { prisma } from '@repo/db';
 import { getServerAuthSession } from '@repo/auth/server';
+import { prisma } from '@repo/db';
+import { type Prisma, type Report } from '@repo/db/types';
 
 // FML this was obnoxious to do
 export type ChallengeInfo = Omit<Report, 'id' | 'status' | 'type' | 'userId'> & {
@@ -233,6 +233,11 @@ export async function getChallenge(id: number) {
           vote: true,
           bookmark: true,
           comment: true,
+        },
+      },
+      user: {
+        select: {
+          name: true,
         },
       },
     },

--- a/apps/admin/src/app/report/[id]/_components/report/challenge.report.tsx
+++ b/apps/admin/src/app/report/[id]/_components/report/challenge.report.tsx
@@ -1,8 +1,8 @@
-import { ThumbsUp } from '@repo/ui/icons';
 import { Markdown, Text, UserBadge } from '@repo/ui';
+import { ThumbsUp } from '@repo/ui/icons';
 import Link from 'next/link';
-import type { ReportWithInfo } from '../../report.action';
 import { getChallenge } from '~/app/_components/admin.actions';
+import type { ReportWithInfo } from '../../report.action';
 
 export interface ChallengeReportProps {
   report: NonNullable<ReportWithInfo>;

--- a/apps/admin/src/app/report/[id]/_components/report/report.action.ts
+++ b/apps/admin/src/app/report/[id]/_components/report/report.action.ts
@@ -34,9 +34,13 @@ export async function getReports(lastCursor?: number, take = 3) {
               vote: true,
             },
           },
+          user: {
+            select: {
+              name: true,
+            },
+          },
         },
       },
-      user: true,
       reporter: true,
       issues: true,
       comment: true,
@@ -66,7 +70,11 @@ export async function getReportedUserInformation(userId: string) {
       comment: {
         take: 10,
         include: {
-          user: true,
+          user: {
+            select: {
+              name: true,
+            },
+          },
           _count: {
             select: {
               replies: true,

--- a/apps/admin/src/app/report/[id]/report.action.ts
+++ b/apps/admin/src/app/report/[id]/report.action.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@repo/db';
 
+// todo: remove this. it's not used.
 export async function getReports() {
   const challengeReports = await prisma.report.findMany({
     where: {
@@ -35,14 +36,22 @@ export async function getReport(idNum: number) {
       type: 'asc',
     },
     include: {
+      user: {
+        select: {
+          name: true,
+        },
+      },
       challenge: {
         include: {
-          user: true,
+          user: {
+            select: {
+              name: true,
+            },
+          },
         },
       },
       comment: {
         include: {
-          user: true,
           _count: {
             select: {
               replies: true,
@@ -50,17 +59,33 @@ export async function getReport(idNum: number) {
           },
           rootChallenge: true,
           rootSolution: true,
+          user: {
+            select: {
+              name: true,
+            },
+          },
         },
       },
       issues: true,
-      reporter: true,
-      solution: {
-        include: {
-          user: true,
+      reporter: {
+        select: {
+          name: true,
         },
       },
-      user: true,
-      moderator: true,
+      solution: {
+        include: {
+          user: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      },
+      moderator: {
+        select: {
+          name: true,
+        },
+      },
     },
   });
 }
@@ -70,7 +95,7 @@ export async function getReportedUserInformation(userId: string) {
     where: {
       id: userId,
     },
-    include: {
+    select: {
       comment: {
         take: 10,
         orderBy: {

--- a/apps/web/src/app/challenge/[id]/getChallengeRouteData.ts
+++ b/apps/web/src/app/challenge/[id]/getChallengeRouteData.ts
@@ -13,7 +13,11 @@ export const getChallengeRouteData = cache((id: string, session: Session | null)
       status: 'ACTIVE',
     },
     include: {
-      user: true,
+      user: {
+        select: {
+          name: true,
+        },
+      },
       _count: {
         select: {
           vote: {

--- a/apps/web/src/app/challenge/[id]/solutions/[solutionId]/page.tsx
+++ b/apps/web/src/app/challenge/[id]/solutions/[solutionId]/page.tsx
@@ -22,7 +22,12 @@ async function getSolution(solutionId: string) {
     },
     include: {
       challenge: true,
-      user: true,
+      user: {
+        select: {
+          name: true,
+          image: true,
+        },
+      },
     },
   });
 

--- a/apps/web/src/app/challenge/[id]/solutions/page.tsx
+++ b/apps/web/src/app/challenge/[id]/solutions/page.tsx
@@ -1,7 +1,7 @@
 import type { Session } from '@repo/auth/server';
-import { notFound } from 'next/navigation';
 import { getServerAuthSession } from '@repo/auth/server';
 import { prisma } from '@repo/db';
+import { notFound } from 'next/navigation';
 import { Solutions } from './_components';
 
 interface Props {
@@ -46,7 +46,11 @@ export async function getSolutionsData(challengeId: string, session: Session | n
           },
         ],
         include: {
-          user: true,
+          user: {
+            select: {
+              name: true,
+            },
+          },
           _count: {
             select: { vote: true, solutionComment: true },
           },

--- a/apps/web/src/app/challenge/_components/comments/getCommentRouteData.ts
+++ b/apps/web/src/app/challenge/_components/comments/getCommentRouteData.ts
@@ -82,7 +82,12 @@ export async function getPaginatedComments({
     },
     orderBy: orderBy(sortKey, sortOrder),
     include: {
-      user: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
       _count: {
         select: {
           replies: true,

--- a/apps/web/src/app/explore/_components/explore.action.ts
+++ b/apps/web/src/app/explore/_components/explore.action.ts
@@ -33,7 +33,11 @@ export async function getChallengesByTagOrDifficulty(str: string, take?: number)
       _count: {
         select: { vote: true, comment: true },
       },
-      user: true,
+      user: {
+        select: {
+          name: true,
+        },
+      },
     },
     ...(take && {
       take,

--- a/apps/web/src/app/tracks/_components/track.action.ts
+++ b/apps/web/src/app/tracks/_components/track.action.ts
@@ -65,7 +65,6 @@ export async function getTrackDetails(id: number) {
         where: {
           id: session?.user.id,
         },
-        // ensure's we don't leak user data other than the necessary parameters.
         select: {
           id: true,
         },

--- a/apps/web/src/components/user/dashboard/index.tsx
+++ b/apps/web/src/components/user/dashboard/index.tsx
@@ -1,31 +1,32 @@
-import Image from 'next/image';
-import type { User } from '@repo/db/types';
-import Link from 'next/link';
 import { getServerAuthSession } from '@repo/auth/server';
-import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { prisma } from '@repo/db';
+import type { User } from '@repo/db/types';
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
+  MagicIcon,
   Tabs,
   VerticalTabsContent,
-  VerticalTabsTrigger,
-  MagicIcon,
   VerticalTabsList,
+  VerticalTabsTrigger,
 } from '@repo/ui';
-import { Overview } from './overview';
-import { InProgressTab } from './in-progress-tab';
-import { SolutionsTab } from './solutions-tab';
-import UserHeader from './user-header';
+import { Bookmark, ChevronRightSquare, MessagesSquare, Play, Settings } from 'lucide-react';
+import Link from 'next/link';
+import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { getRelativeTime } from '~/utils/relativeTime';
 import { stripProtocolAndWWW } from '~/utils/stringUtils';
-import { Bookmark, ChevronRightSquare, MessagesSquare, Play, Settings } from 'lucide-react';
+import { InProgressTab } from './in-progress-tab';
+import { Overview } from './overview';
+import { SolutionsTab } from './solutions-tab';
+import UserHeader from './user-header';
 
 interface Props {
   // TODO: how do do this union type with just letting prisma halp
-  user: User & { userLinks: { id: string | null; url: string }[] };
+  user: Pick<User, 'bio' | 'createdAt' | 'id' | 'image' | 'name'> & {
+    userLinks: { id: string | null; url: string }[];
+  };
 }
 
 export type UserData = NonNullable<Awaited<ReturnType<typeof getUserdata>>>;
@@ -34,7 +35,7 @@ async function getUserdata(id: string) {
     where: {
       id,
     },
-    include: {
+    select: {
       submission: {
         where: {
           userId: id,

--- a/apps/web/src/components/user/dashboard/user-header.tsx
+++ b/apps/web/src/components/user/dashboard/user-header.tsx
@@ -6,7 +6,7 @@ import { ActionMenu, Text } from '@repo/ui';
 import { ReportDialog } from '~/components/ReportDialog';
 
 export interface UserHeaderProps {
-  user: User;
+  user: Pick<User, 'id' | 'name'>;
   isOwnProfile: boolean;
 }
 

--- a/apps/web/src/components/user/profile.tsx
+++ b/apps/web/src/components/user/profile.tsx
@@ -1,6 +1,6 @@
-import { notFound } from 'next/navigation';
-import type { Metadata } from 'next';
 import { prisma } from '@repo/db';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import Dashboard from './dashboard';
 
 interface Props {
@@ -23,7 +23,12 @@ export async function Profile({ username: usernameFromQuery }: Props) {
         equals: username,
       },
     },
-    include: {
+    select: {
+      id: true,
+      createdAt: true,
+      bio: true,
+      image: true,
+      name: true,
       userLinks: true,
     },
   });


### PR DESCRIPTION
### Issue
closes #454

### Changes
- refactored "user" related queries to only include information that is displayed on front-end.
- replaced the queries to use `select` instead of `include` at some places.
