### PR TITLE
only allow sentry in staging/production envs

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -22,6 +22,12 @@ Sentry.init({
   // in development and sample at a lower rate in production
   replaysSessionSampleRate: 0.1,
 
+  enabled: process.env.NODE_ENV === 'production',
+  environment:
+    window.origin.includes('staging') || window.origin.includes('vercel.app')
+      ? 'Staging'
+      : 'Production',
+
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [
     new Sentry.Replay({


### PR DESCRIPTION
closes (hopefully) #579

docs: https://docs.sentry.io/platforms/javascript/configuration/options/#environment