### PR TITLE
fix: Remove TS Diagnostics from validations

### DIFF
--- a/apps/web/src/components/wizard/TestCasesEditor.tsx
+++ b/apps/web/src/components/wizard/TestCasesEditor.tsx
@@ -51,7 +51,6 @@ export function TestCasesEditor({ form, hasTsErrors, setTsErrors }: Props) {
         const errors = await Promise.all([
           ts.getSemanticDiagnostics(filename),
           ts.getSyntacticDiagnostics(filename),
-          ts.getSuggestionDiagnostics(filename),
           ts.getCompilerOptionsDiagnostics(filename),
         ] as const);
 

--- a/apps/web/src/components/wizard/index.tsx
+++ b/apps/web/src/components/wizard/index.tsx
@@ -68,7 +68,7 @@ export function Wizard() {
   const { data: session } = useSession();
   const [step, setStep] = useState(0);
   const [rendered, setRendered] = useState(false);
-  const [tsErrors, setTsErrors] = useState<TsErrors>([[], [], [], []]);
+  const [tsErrors, setTsErrors] = useState<TsErrors>([[], [], []]);
 
   const isUserACreator = useMemo(
     () => session?.user?.role.includes('CREATOR') ?? false,

--- a/packages/monaco/src/index.tsx
+++ b/packages/monaco/src/index.tsx
@@ -32,7 +32,6 @@ export interface CodePanelProps {
 export type TsErrors = [
   SemanticDiagnostics: monaco.languages.typescript.Diagnostic[],
   SyntacticDiagnostics: monaco.languages.typescript.Diagnostic[],
-  SuggestionDiagnostics: monaco.languages.typescript.Diagnostic[],
   CompilerOptionsDiagnostics: monaco.languages.typescript.Diagnostic[],
 ];
 
@@ -104,7 +103,7 @@ export function CodePanel(props: CodePanelProps) {
           onMount={{
             tests: (editor) => {
               setTestEditorState(editor);
-              setTsErrors([[], [], [], []]);
+              setTsErrors([[], [], []]);
             },
             user: async (editor, monaco) => {
               setMonacoInstance(monaco);
@@ -152,7 +151,6 @@ export function CodePanel(props: CodePanelProps) {
               const errors = await Promise.all([
                 tsWorker.getSemanticDiagnostics(TESTS_PATH),
                 tsWorker.getSyntacticDiagnostics(TESTS_PATH),
-                Promise.resolve([]),
                 tsWorker.getCompilerOptionsDiagnostics(TESTS_PATH),
               ] as const);
 


### PR DESCRIPTION
Closes #374