### PR TITLE
fix editor-types.ts

### DIFF
--- a/packages/monaco/src/editor-types.ts
+++ b/packages/monaco/src/editor-types.ts
@@ -89,7 +89,7 @@ declare function NotEqual<A, B>(
 declare function Extends<A, B>(
   ...args: [
     ...([a: A, b: B] | []),
-    ...(A extends B ? [] : [msg: [A, "doesn't extend", B]])
+    ...([A] extends [B] ? [] : [msg: [A, "doesn't extend", B]])
   ]
 ): void;
 `;


### PR DESCRIPTION
This fixes a small issue with the `Extends` helper to make sure that if it is a union it still works