### PR TITLE
Lift comment state into url

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[id]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[id]/solutions/_components/index.tsx
@@ -83,10 +83,9 @@ function SolutionRow({
         </div>
         <Link
           href={`/challenge/${solution.challengeId}/solutions/${solution.id}?showComments=true`}
+          className="mr-2 flex cursor-pointer items-center gap-2 rounded-full bg-neutral-100 px-2 py-1 text-sm  duration-300 hover:bg-neutral-200 dark:bg-zinc-700 dark:hover:bg-zinc-600"
         >
-          <button className="mr-2 flex cursor-pointer items-center gap-2 rounded-full bg-neutral-100 px-2 py-1 text-sm  duration-300 hover:bg-neutral-200 dark:bg-zinc-700 dark:hover:bg-zinc-600">
-            <MessageCircle className="h-4 w-4 stroke-1" /> {solution._count.solutionComment}
-          </button>
+          <MessageCircle className="h-4 w-4 stroke-1" /> {solution._count.solutionComment}
         </Link>
         {/* TODO: voted state */}
         {/* bg-emerald-600/10 text-emerald-600 duration-300 hover:bg-emerald-600/20 dark:bg-emerald-400/20 dark:text-emerald-400 dark:hover:bg-emerald-400/40*/}

--- a/apps/web/src/app/[locale]/challenge/[id]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[id]/solutions/_components/index.tsx
@@ -81,9 +81,13 @@ function SolutionRow({
         <div className="mr-auto text-sm text-neutral-500">
           {getRelativeTime(solution.createdAt)}
         </div>
-        <button className="mr-2 flex cursor-pointer items-center gap-2 rounded-full bg-neutral-100 px-2 py-1 text-sm  duration-300 hover:bg-neutral-200 dark:bg-zinc-700 dark:hover:bg-zinc-600">
-          <MessageCircle className="h-4 w-4 stroke-1" /> {solution._count.solutionComment}
-        </button>
+        <Link
+          href={`/challenge/${solution.challengeId}/solutions/${solution.id}?showComments=true`}
+        >
+          <button className="mr-2 flex cursor-pointer items-center gap-2 rounded-full bg-neutral-100 px-2 py-1 text-sm  duration-300 hover:bg-neutral-200 dark:bg-zinc-700 dark:hover:bg-zinc-600">
+            <MessageCircle className="h-4 w-4 stroke-1" /> {solution._count.solutionComment}
+          </button>
+        </Link>
         {/* TODO: voted state */}
         {/* bg-emerald-600/10 text-emerald-600 duration-300 hover:bg-emerald-600/20 dark:bg-emerald-400/20 dark:text-emerald-400 dark:hover:bg-emerald-400/40*/}
         <button className="flex cursor-pointer items-center gap-2 rounded-full bg-neutral-100 px-2 py-1 text-sm duration-300 hover:bg-neutral-200 dark:bg-zinc-700 dark:hover:bg-zinc-600 ">

--- a/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
@@ -12,15 +12,16 @@ import {
   toast,
 } from '@repo/ui';
 import {
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   MessageCircle,
-  ArrowDownNarrowWide,
-  ArrowUpNarrowWide,
 } from '@repo/ui/icons';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import clsx from 'clsx';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
 import { Comment } from './comment';
 import { CommentInput } from './comment-input';
@@ -49,7 +50,6 @@ interface Props {
 }
 
 export function Comments({ rootId, type }: Props) {
-  const [showComments, setShowComments] = useState(false);
   const [text, setText] = useState('');
   const commentContainerRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
@@ -66,6 +66,11 @@ export function Comments({ rootId, type }: Props) {
     keepPreviousData: true,
     staleTime: 5000,
   });
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const showComments = searchParams.has('showComments');
+  const router = useRouter();
 
   async function createChallengeComment() {
     try {
@@ -116,7 +121,15 @@ export function Comments({ rootId, type }: Props) {
       <div className="relative">
         <button
           className="flex w-full items-center justify-between gap-2 p-3 font-medium text-neutral-500 duration-300 hover:text-neutral-700 focus:outline-none dark:hover:text-zinc-300"
-          onClick={() => setShowComments(!showComments)}
+          onClick={() => {
+            const current = new URLSearchParams(Array.from(searchParams.entries()));
+            if (showComments) {
+              current.delete('showComments');
+            } else {
+              current.set('showComments', 'true');
+            }
+            router.push(`${pathname}?${current.toString()}`);
+          }}
         >
           <div className="flex items-center gap-2">
             <MessageCircle className="h-5 w-5" />


### PR DESCRIPTION
This PR lifts the state of the show/hide comments window into the URL.

The advantage is that we can now directly link to the open comments window. This was presented by the view where the hover state indicates that comments / upvotes are clickable and provide their own action

Upon click on the comments button this will now leverage the opportunity and directly show the comments tab

https://jmp.sh/xWs4e6xD