### PR TITLE
feat(web): remove sentry replay

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -16,24 +16,9 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  replaysOnErrorSampleRate: 1.0,
-
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
   enabled: process.env.NODE_ENV === 'production',
   environment:
     window.origin.includes('staging') || window.origin.includes('vercel.app')
       ? 'Staging'
       : 'Production',
-
-  // You can remove this option if you're not planning to use the Sentry Session Replay feature:
-  integrations: [
-    new Sentry.Replay({
-      // Additional Replay configuration goes in here, for example:
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
 });


### PR DESCRIPTION
Following https://github.com/typehero/typehero/pull/616, we don't need Sentry replays at all

| Before | After |
|--------|--------|
| ![image](https://github.com/typehero/typehero/assets/43268759/584f2392-367e-4ce5-86f5-bd55f5f44d29) | ![Screenshot 2023-09-06 at 08 54 50](https://github.com/typehero/typehero/assets/43268759/e52fbdb6-ab40-4ef9-950d-6eb4f2ebbadb) |

