### PR TITLE
fix(web): static site generation

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,9 +1,9 @@
 import { getStaticParams } from '~/locales/server';
 
 export function generateStaticParams() {
-  return getStaticParams()
+  return getStaticParams();
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return children
+  return children;
 }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,0 +1,9 @@
+import { getStaticParams } from '~/locales/server';
+
+export function generateStaticParams() {
+  return getStaticParams()
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return children
+}


### PR DESCRIPTION
Enable static site generation since all routes are now dynamic because of i18n.

| Before | After |
|--------|--------|
| ![Screenshot 2023-09-06 at 08 54 50](https://github.com/typehero/typehero/assets/43268759/21c00538-edf1-4c2b-b684-74a8ee089926) | <img width="818" alt="Screenshot 2023-09-06 at 12 23 12" src="https://github.com/typehero/typehero/assets/43268759/9fe5a46c-a6d1-421b-8a5d-82dd8a05bb9c"> |
