### PR TITLE
remove prisma from client bundle

### DIFF
--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { signIn, signOut, useSession } from '@repo/auth/react';
-import { RoleTypes } from '@repo/db/types';
+import { type RoleTypes } from '@repo/db/types';
 import {
   Button,
   DropdownMenu,
@@ -28,6 +28,13 @@ export function getAdminUrl() {
   // assume localhost
   return `http://localhost:3001`;
 }
+
+const roleTypes: typeof RoleTypes = {
+  USER: 'USER',
+  ADMIN: 'ADMIN',
+  MODERATOR: 'MODERATOR',
+  CREATOR: 'CREATOR',
+};
 
 export function Navigation() {
   const { fssettings } = useFullscreenSettingsStore();
@@ -150,8 +157,8 @@ function LoginButton() {
   const { data: session, status } = useSession();
   const router = useRouter();
 
-  const isAdmin = session?.user.role.includes(RoleTypes.ADMIN);
-  const isMod = session?.user.role.includes(RoleTypes.MODERATOR);
+  const isAdmin = session?.user.role.includes(roleTypes.ADMIN);
+  const isMod = session?.user.role.includes(roleTypes.MODERATOR);
   const isAdminOrMod = isAdmin || isMod;
 
   // NOTE: 1. loading == true -> 2. signIn() -> 3. session status == 'loading' (loading == false)


### PR DESCRIPTION
This removes @prisma/client from the client bundle

## Description
Due to the fact that we imported a value from prisma client instead of only types, the whole prisma/client was bundled into the client bundles. This will remove roughly 26kb gzipped. 

I was not sure how to handle this best and also tried to create a server action for this. But in the end I think this works too as
1. The types are pretty stable and don't change
2. if the schema changes linting also will fail making sure the object will be adjusted

## Motivation and Context
We have too much JS for a static page

## How Has This Been Tested?
pnpm build -> check imported chunks for prisma output

