### PR TITLE
tooltip for reset button

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/reset-editor-button.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/reset-editor-button.tsx
@@ -8,6 +8,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@repo/ui';
 import { RotateCcw } from '@repo/ui/icons';
 
@@ -16,7 +19,14 @@ const ResetEditorButton = () => {
   return (
     <AlertDialog>
       <AlertDialogTrigger>
-        <RotateCcw className="stroke-zinc-500 stroke-1 hover:stroke-zinc-400" size={20} />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <RotateCcw className="stroke-zinc-500 stroke-1 hover:stroke-zinc-400" size={20} />
+          </TooltipTrigger>
+          <TooltipContent side="left">
+            <p>Reset to default code definition</p>
+          </TooltipContent>
+        </Tooltip>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added tooltip for reset button in the challenge editor 

## Related Issue
Closes #622 

## Motivation and Context
Maintain consistency and provide the user info with what the button does

## How Has This Been Tested?
By hovering over the reset button

## Screenshots/Video (if applicable):

https://github.com/typehero/typehero/assets/32938743/b873dade-a3bc-48cc-a831-4b319835fa9c


@PickleNik please have a look! 