### PR TITLE
feat(web): static rendering on `/`

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,7 @@
     "million": "2.6.0-beta.12",
     "monaco-vim": "^0.4.0",
     "next": "^13.4.19",
-    "next-international": "1.0.0-rc.4",
+    "next-international": "1.0.0-rc.6",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-day-picker": "^8.8.0",

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -4,6 +4,8 @@ import { Community } from './_components/community/community';
 import { Features } from './_components/features';
 import { Hero } from './_components/hero';
 import { WaitlistBanner } from './_components/waitlist-banner';
+import { getStaticParams } from '~/locales/server';
+import { setStaticParamsLocale } from 'next-international/server';
 
 export const metadata: Metadata = {
   title: 'TypeHero',
@@ -11,7 +13,13 @@ export const metadata: Metadata = {
     'Connect, collaborate, and grow with a community of TypeScript developers. Elevate your skills through interactive coding challenges, discussions, and knowledge sharing',
 };
 
-export default async function Index() {
+export function generateStaticParams() {
+  return getStaticParams();
+}
+
+export default async function Index({ params: { locale } }: { params: { locale: string } }) {
+  setStaticParamsLocale(locale);
+
   return (
     <>
       <Hero />

--- a/apps/web/src/app/[locale]/waitlist/page.tsx
+++ b/apps/web/src/app/[locale]/waitlist/page.tsx
@@ -1,13 +1,8 @@
 import type { Metadata } from 'next';
-import { getStaticParams } from '~/locales/server';
 
 export const metadata: Metadata = {
   title: 'Waitlist | TypeHero',
   description: 'Join the waitlist for TypeHero and be the first to know when we launch!',
 };
-
-export function generateStaticParams() {
-  return getStaticParams();
-}
 
 export { Waitlist as default } from './_components';

--- a/apps/web/src/app/[locale]/waitlist/page.tsx
+++ b/apps/web/src/app/[locale]/waitlist/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from 'next';
-
-export { Waitlist as default } from './_components';
+import { getStaticParams } from '~/locales/server';
 
 export const metadata: Metadata = {
   title: 'Waitlist | TypeHero',
   description: 'Join the waitlist for TypeHero and be the first to know when we launch!',
 };
+
+export function generateStaticParams() {
+  return getStaticParams();
+}
+
+export { Waitlist as default } from './_components';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,8 +292,8 @@ importers:
         specifier: ^13.4.19
         version: 13.4.19(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       next-international:
-        specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4
+        specifier: 1.0.0-rc.6
+        version: 1.0.0-rc.6
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@13.4.19)(react-dom@18.2.0)(react@18.2.0)
@@ -676,7 +676,7 @@ importers:
     dependencies:
       '@next/eslint-plugin-next':
         specifier: canary
-        version: 13.4.20-canary.0
+        version: 13.4.20-canary.15
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../config-typescript
@@ -688,7 +688,7 @@ importers:
         version: 5.62.0(eslint@8.45.0)(typescript@5.1.6)
       '@vercel/style-guide':
         specifier: ^4.0.2
-        version: 4.0.2(@next/eslint-plugin-next@13.4.20-canary.0)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
+        version: 4.0.2(@next/eslint-plugin-next@13.4.20-canary.15)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
       eslint:
         specifier: ^8.40.0
         version: 8.45.0
@@ -1773,8 +1773,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/eslint-plugin-next@13.4.20-canary.0:
-    resolution: {integrity: sha512-vFC1meiw/awh2xJZMWaoECsfZbgkt2fF3HIg8f2fSM/w41Z86L1SS7SjKmpbbD87yq3tiqgqHmFv0JCych4g4g==}
+  /@next/eslint-plugin-next@13.4.20-canary.15:
+    resolution: {integrity: sha512-Bolwt8DYYASzNADy9XIu/q5tLp+/9pVL3DWuaSWpb4UvaJMgyHIgmi+5pM5oRQiC7BwBDErnTBdiEmaP7zl/dQ==}
     dependencies:
       glob: 7.1.7
     dev: false
@@ -4373,7 +4373,7 @@ packages:
       yoga-wasm-web: 0.3.0
     dev: false
 
-  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@13.4.20-canary.0)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
+  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@13.4.20-canary.15)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -4393,7 +4393,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.10
       '@babel/eslint-parser': 7.22.10(@babel/core@7.22.10)(eslint@8.45.0)
-      '@next/eslint-plugin-next': 13.4.20-canary.0
+      '@next/eslint-plugin-next': 13.4.20-canary.15
       '@rushstack/eslint-patch': 1.3.2
       '@typescript-eslint/eslint-plugin': 5.59.1(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
@@ -8266,8 +8266,8 @@ packages:
     dev: false
     patched: true
 
-  /next-international@1.0.0-rc.4:
-    resolution: {integrity: sha512-okY1xqSixMiRCfpSdt4or7Lup9pwVAITEC1rPdt/wfqkbK15gJwxbc087tYXiHzAlLaL9IszaUjHnJwBQnrISg==}
+  /next-international@1.0.0-rc.6:
+    resolution: {integrity: sha512-SZN7vYJxu+wWjvN63TBrS7gDrkbtqWYzsb+buEaDf4LYgCUErEwGjJeertZJCz54uLPVDMp4qRbE/0bDxyKPzQ==}
     dependencies:
       client-only: 0.0.1
       international-types: 0.8.0


### PR DESCRIPTION
Enable static rendering only for `/`, so it doesn't break other pages that have server actions.