### PR TITLE
fix: Ensures tooltips in challenges render under nav

### DIFF
--- a/apps/admin/src/components/navigation.tsx
+++ b/apps/admin/src/components/navigation.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 
 export function Navigation() {
   return (
-    <header className="z-10 w-full">
+    <header className="z-0 w-full">
       <nav className="container flex h-14 items-center">
         <div className="flex w-full items-center justify-between">
           <div className="relative flex gap-3">

--- a/apps/web/src/components/ui/navigation.tsx
+++ b/apps/web/src/components/ui/navigation.tsx
@@ -42,7 +42,7 @@ export function Navigation() {
   const featureFlags = useContext(FeatureFlagContext);
 
   return (
-    <header className="z-10 w-full">
+    <header className="z-0 w-full">
       {!fssettings.isFullscreen && (
         <nav
           className={`flex h-14 items-center text-sm font-medium ${


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes z-10 to z-0 on the nav components -- this ensures tooltips are rendering over them (tooltips already have z-50, but am not sure why it is rendering below the nav)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Should fix #638

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Necessary to ensure that tooltips are readable always (future proofs the pages as well, pending any changes/additions to icon buttons on nav)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested visually on challenge/submissions page

## Screenshots/Video (if applicable):

![image](https://github.com/typehero/typehero/assets/28593720/63ec9c9c-8c45-4737-9b56-c047f4ee3fcc)
