### PR TITLE
disable comment input box while user was logged out #649

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
@@ -52,11 +52,16 @@ export function CommentInput({ mode, onCancel, onChange, value, placeholder, onS
     <div className="flex flex-col rounded-xl rounded-br-lg bg-neutral-100 backdrop-blur-sm dark:border-zinc-700 dark:bg-zinc-700/90">
       {commentMode === 'editor' && (
         <Textarea
+          disabled={!session?.user}
           autoFocus
           className="resize-none border-0 px-3 py-2 focus-visible:ring-0 md:max-h-[calc(100vh_-_232px)]"
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleEnterKey}
-          placeholder={placeholder ?? 'Enter your comment here.'}
+          placeholder={
+            placeholder ?? !session?.user
+              ? 'You need to be logged in to comment.'
+              : 'Enter your comment here.'
+          }
           ref={textAreaRef}
           value={value}
         />


### PR DESCRIPTION
disable comment input box while user was logged out

this PR fixes #649

## Description
updated placeholder of comment input if user isn't logged in

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

![image](https://github.com/typehero/typehero/assets/72158561/93aff380-31c7-49b4-8914-cb98d7329068)
