### PR TITLE
Fixed light mode issue with test panel

### DIFF
--- a/packages/monaco/src/index.tsx
+++ b/packages/monaco/src/index.tsx
@@ -92,7 +92,7 @@ export function CodePanel(props: CodePanelProps) {
 
   return (
     <>
-      <div className="sticky top-0 flex h-[40px] shrink-0 items-center justify-end gap-4 border-b border-zinc-300 px-3 py-2 dark:border-zinc-700 dark:bg-[#1e1e1e]">
+      <div className="sticky top-0 flex h-[40px] shrink-0 items-center justify-end gap-4 border-b border-zinc-300 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-[#1e1e1e]">
         {props.settingsElement}
       </div>
       <SplitEditor
@@ -185,7 +185,7 @@ export function CodePanel(props: CodePanelProps) {
           {
             'justify-between': testEditorState,
           },
-          'sticky bottom-0 flex items-center justify-between border-t border-zinc-300 p-2 dark:border-zinc-700 dark:bg-[#1e1e1e]',
+          'sticky bottom-0 flex items-center justify-between border-t border-zinc-300 bg-white p-2 dark:border-zinc-700 dark:bg-[#1e1e1e]',
         )}
       >
         <div className="flex items-center gap-4">

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -236,10 +236,10 @@ export default function SplitEditor({
         ref={testPanel}
       >
         <div
-          className="cursor-row-resize border-y border-zinc-300 bg-zinc-800 p-2 dark:border-zinc-700"
+          className="cursor-row-resize border-y border-zinc-200 bg-zinc-100 p-2 dark:border-zinc-700 dark:bg-zinc-800"
           ref={resizer}
         >
-          <div className="m-auto h-1 w-24 rounded-full bg-zinc-700" />
+          <div className="m-auto h-1 w-24 rounded-full  bg-zinc-300 dark:bg-zinc-700" />
         </div>
         <CodeEditor
           options={{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In light mode, the test panel dragger maintained the same color as the dark mode.

## How Has This Been Tested?
Tested visually in all the browsers.

## Screenshots/Video (if applicable):
Before

https://github.com/typehero/typehero/assets/32938743/0ee3fdaa-60b3-46c1-98cf-8ce960cd4870

After

https://github.com/typehero/typehero/assets/32938743/8945bfeb-ec72-476a-8561-31c289fcb0ea

