### PR TITLE
Fix: 654 bug submit button disabled when not logged in

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
@@ -25,6 +25,7 @@ import {
 } from '@repo/ui/components/dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
 import { Markdown } from '@repo/ui/components/markdown';
+import { Button } from '@repo/ui/components/button';
 
 interface Props {
   challenge: ChallengeRouteData;
@@ -107,7 +108,7 @@ export function Description({ challenge }: Props) {
         </Dialog>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
+            <Button
               className="group flex h-6 items-center rounded-full bg-zinc-200 px-3 focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-zinc-100 dark:bg-zinc-700 disabled:dark:bg-zinc-700/50"
               disabled={!session.data?.user.id}
               onClick={() => {
@@ -136,7 +137,7 @@ export function Description({ challenge }: Props) {
                   'h-4 w-4',
                 )}
               />
-            </button>
+            </Button>
           </TooltipTrigger>
           <TooltipContent>
             <p>{session.data?.user.id ? 'Bookmark' : 'Login to Bookmark'}</p>

--- a/apps/web/src/app/[locale]/challenge/_components/vote.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/vote.tsx
@@ -8,6 +8,7 @@ import { debounce } from 'lodash';
 import { useRef, useState } from 'react';
 import { incrementOrDecrementUpvote } from '../increment.action';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
+import { Button } from '@repo/ui/components/button';
 
 interface VoteProps {
   voteCount: number;
@@ -39,8 +40,8 @@ export function Vote({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <button
-          className="group flex h-6 items-center gap-1 rounded-full bg-zinc-200 pl-[0.675rem] pr-2 text-sm focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-zinc-100 dark:bg-zinc-700 disabled:dark:bg-zinc-700/50"
+        <Button
+          className="py-0 group flex h-6 items-center gap-1 rounded-full bg-zinc-200 pl-[0.675rem] pr-2 text-sm focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-zinc-100 dark:bg-zinc-700 disabled:dark:bg-zinc-700/50"
           disabled={disabled}
           onClick={() => {
             let shouldIncrement = false;
@@ -74,7 +75,7 @@ export function Vote({
                 'stroke-zinc-500 group-hover:stroke-zinc-600 group-disabled:stroke-zinc-300 dark:stroke-zinc-300 group-hover:dark:stroke-zinc-100 group-disabled:dark:stroke-zinc-500/50':
                   !hasVoted,
               },
-              'h-4 w-4 duration-200',
+              'my-auto h-4 w-4 duration-200',
             )}
           />
           <span
@@ -89,7 +90,7 @@ export function Vote({
           >
             {votes}
           </span>
-        </button>
+        </Button>
       </TooltipTrigger>
       <TooltipContent>
         <p>{session.data?.user.id ? 'Upvote' : 'Login to Upvote'}</p>

--- a/apps/web/src/app/[locale]/challenge/_components/vote.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/vote.tsx
@@ -41,7 +41,7 @@ export function Vote({
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
-          className="py-0 group flex h-6 items-center gap-1 rounded-full bg-zinc-200 pl-[0.675rem] pr-2 text-sm focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-zinc-100 dark:bg-zinc-700 disabled:dark:bg-zinc-700/50"
+          className="group flex h-6 items-center gap-1 rounded-full bg-zinc-200 py-0 pl-[0.675rem] pr-2 text-sm focus:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:bg-zinc-100 dark:bg-zinc-700 disabled:dark:bg-zinc-700/50"
           disabled={disabled}
           onClick={() => {
             let shouldIncrement = false;

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:cursor-not-allowed ring-offset-background',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Description
This PR solves #654. I added the utility CSS class `disabled:cursor-not-allowed` instead of `disabled:pointer-events-none` so the tooltip can show on the `Button` component.

## Related Issue
Issue #654 

## How Has This Been Tested?
Works on light and dark mode. Only shows up if not logged in.

## Screenshots/Video (if applicable):
<img width="240" alt="image" src="https://github.com/typehero/typehero/assets/44373521/29337517-c9d3-4bc6-95d8-f31727a22a23">
<img width="240" alt="image" src="https://github.com/typehero/typehero/assets/44373521/4afd5691-892f-41fc-a287-fa75de914948">
<img width="240" alt="image" src="https://github.com/typehero/typehero/assets/44373521/f59209fb-d45a-482a-8a73-b49bd3ec758f">

