### PR TITLE
Adjust tests panel

### DIFF
--- a/packages/monaco/src/index.tsx
+++ b/packages/monaco/src/index.tsx
@@ -189,26 +189,38 @@ export function CodePanel(props: CodePanelProps) {
         )}
       >
         <div className="flex items-center gap-4">
-          <Button
-            className="flex items-center gap-1"
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              setIsTestPanelExpanded((tp) => !tp);
-            }}
-          >
-            Tests
-            {isTestPanelExpanded ? (
-              <ChevronUp className="rotate-180 transform transition" size={16} />
-            ) : (
-              <ChevronUp className="transform transition" size={16} />
-            )}
-          </Button>
-          {hasFailingTest ? (
-            <XCircle className="stroke-red-600 dark:stroke-red-300" />
-          ) : (
-            <CheckCircle2 className="stroke-green-600 dark:stroke-green-300" />
-          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                className="flex items-center gap-1"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setIsTestPanelExpanded((tp) => !tp);
+                }}
+              >
+                Tests
+                {isTestPanelExpanded ? (
+                  <ChevronUp className="rotate-180 transform transition" size={16} />
+                ) : (
+                  <ChevronUp className="transform transition" size={16} />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{isTestPanelExpanded ? 'Hide tests' : 'Show tests'}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {hasFailingTest ? (
+                <XCircle className="stroke-red-600 dark:stroke-red-300" />
+              ) : (
+                <CheckCircle2 className="stroke-green-600 dark:stroke-green-300" />
+              )}
+            </TooltipTrigger>
+            <TooltipContent>
+              {hasFailingTest ? 'Tests are failing' : 'All tests have passed 🎉'}
+            </TooltipContent>
+          </Tooltip>
         </div>
         <div className="flex items-center justify-between gap-4">
           <Tooltip>

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -238,6 +238,9 @@ export default function SplitEditor({
         <div
           className="cursor-row-resize border-y border-zinc-200 bg-zinc-100 p-2 dark:border-zinc-700 dark:bg-zinc-800"
           ref={resizer}
+          onDoubleClick={() => {
+            setIsTestPanelExpanded(false);
+          }}
         >
           <div className="m-auto h-1 w-24 rounded-full  bg-zinc-300 dark:bg-zinc-700" />
         </div>


### PR DESCRIPTION
Adds tooltips and aligns functionality of resize handle
## Description
This PR enables tooltips for the show / hide tests button as well as for the test status icon.

Additionally it adds tie functionality to close the test panel by double clicking on the resize handle. Just like how it works for the leftwrapper

## How Has This Been Tested?
Visually by looking and clicking
## Screenshots/Video (if applicable):
https://jmp.sh/Nd9CBkjY
