### PR TITLE
Handle type check on code reset

### DIFF
--- a/packages/monaco/src/editor-hooks.ts
+++ b/packages/monaco/src/editor-hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 
 class EditorEvents extends EventTarget {
   dispatch(ev: string) {
@@ -13,13 +13,18 @@ export function useResetEditor(): {
   dispatch: (eventName: EventNames) => void;
 } {
   function subscribe(eventName: EventNames, cb: () => void) {
+    // Memoize the callback to avoid stale closures
+    const memoizedCb = useCallback(() => {
+      cb();
+    }, [cb]);
+
     useEffect(() => {
       const fnc = () => {
-        cb();
+        memoizedCb();
       };
       event.addEventListener(eventName, fnc);
       return () => event.removeEventListener(eventName, fnc);
-    }, []);
+    }, [memoizedCb]);
   }
 
   function dispatch(eventName: EventNames) {

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -8,7 +8,7 @@ import { CodeEditor, LIB_URI } from './code-editor';
 import { libSource } from './editor-types';
 import dynamic from 'next/dynamic';
 import { useEditorSettingsStore } from './settings-store';
-import { getEventDeltas } from './utils';
+import { getEventDeltas, typeCheck } from './utils';
 import { useResetEditor } from './editor-hooks';
 
 function preventSelection(event: Event) {
@@ -62,6 +62,7 @@ export default function SplitEditor({
   monaco,
 }: SplitEditorProps) {
   const { settings, updateSettings } = useEditorSettingsStore();
+  const { subscribe } = useResetEditor();
 
   const wrapper = useRef<HTMLDivElement>(null);
   const resizer = useRef<HTMLDivElement>(null);
@@ -178,42 +179,10 @@ export default function SplitEditor({
       }
     }
   }, [monaco]);
-  async function typeCheck() {
+
+  subscribe('resetCode', () => {
     if (monaco && userEditorState) {
-      const models = monaco.editor.getModels();
-      const getWorker = await monaco.languages.typescript.getTypeScriptWorker();
-
-      for (const model of models) {
-        const worker = await getWorker(model.uri);
-        const diagnostics = (
-          await Promise.all([
-            worker.getSyntacticDiagnostics(model.uri.toString()),
-            worker.getSemanticDiagnostics(model.uri.toString()),
-          ])
-        ).reduce((a, b) => a.concat(b));
-
-        const markers = diagnostics.map((d) => {
-          const start = model.getPositionAt(d.start!);
-          const end = model.getPositionAt(d.start! + d.length!);
-
-          return {
-            severity: monaco.MarkerSeverity.Error,
-            startLineNumber: start.lineNumber,
-            endLineNumber: end.lineNumber,
-            startColumn: start.column,
-            endColumn: end.column,
-            message: d.messageText as string,
-          } satisfies monacoType.editor.IMarkerData;
-        });
-
-        monaco.editor.setModelMarkers(model, model.getLanguageId(), markers);
-      }
-    }
-  }
-  const monacoAndEditorStateReady = monaco && userEditorState;
-  useResetEditor().subscribe('resetCode', () => {
-    if (monacoAndEditorStateReady) {
-      typeCheck();
+      typeCheck(monaco);
       onMount?.tests?.(userEditorState, monaco);
     }
   });
@@ -231,36 +200,8 @@ export default function SplitEditor({
           onValidate={onValidate?.user}
           onChange={async (e, a) => {
             if (monaco) {
-              const models = monaco.editor.getModels();
-              const getWorker = await monaco.languages.typescript.getTypeScriptWorker();
-
-              for (const model of models) {
-                const worker = await getWorker(model.uri);
-                const diagnostics = (
-                  await Promise.all([
-                    worker.getSyntacticDiagnostics(model.uri.toString()),
-                    worker.getSemanticDiagnostics(model.uri.toString()),
-                  ])
-                ).reduce((a, b) => a.concat(b));
-
-                const markers = diagnostics.map((d) => {
-                  const start = model.getPositionAt(d.start!);
-                  const end = model.getPositionAt(d.start! + d.length!);
-
-                  return {
-                    severity: monaco.MarkerSeverity.Error,
-                    startLineNumber: start.lineNumber,
-                    endLineNumber: end.lineNumber,
-                    startColumn: start.column,
-                    endColumn: end.column,
-                    message: d.messageText as string,
-                  } satisfies monacoType.editor.IMarkerData;
-                });
-
-                monaco.editor.setModelMarkers(model, model.getLanguageId(), markers);
-              }
+              typeCheck(monaco);
             }
-
             onChange?.user?.(e, a);
           }}
         />

--- a/packages/monaco/src/utils.ts
+++ b/packages/monaco/src/utils.ts
@@ -1,3 +1,5 @@
+import type * as MonacoEditor from 'monaco-editor';
+
 export function getEventDeltas(e: MouseEvent | TouchEvent, origin: { x: number; y: number }) {
   if (e instanceof MouseEvent) {
     return {
@@ -24,4 +26,35 @@ export function getEventDeltas(e: MouseEvent | TouchEvent, origin: { x: number; 
     currPosX: touch.clientX,
     currPosY: touch.clientY,
   };
+}
+
+export async function typeCheck(monaco: typeof MonacoEditor) {
+  const models = monaco.editor.getModels();
+  const getWorker = await monaco.languages.typescript.getTypeScriptWorker();
+
+  for (const model of models) {
+    const worker = await getWorker(model.uri);
+    const diagnostics = (
+      await Promise.all([
+        worker.getSyntacticDiagnostics(model.uri.toString()),
+        worker.getSemanticDiagnostics(model.uri.toString()),
+      ])
+    ).reduce((a, b) => a.concat(b));
+
+    const markers = diagnostics.map((d) => {
+      const start = model.getPositionAt(d.start!);
+      const end = model.getPositionAt(d.start! + d.length!);
+
+      return {
+        severity: monaco.MarkerSeverity.Error,
+        startLineNumber: start.lineNumber,
+        endLineNumber: end.lineNumber,
+        startColumn: start.column,
+        endColumn: end.column,
+        message: d.messageText as string,
+      } satisfies MonacoEditor.editor.IMarkerData;
+    });
+
+    monaco.editor.setModelMarkers(model, model.getLanguageId(), markers);
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- [x] Memoizes callbacks in `useResetEditor` to avoid stale closures
- [x] Move type checking code into `utils.ts`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #662 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This was almost resolved in #666 🤘🏻 but there was a stale closure that stopped the `typeCheck` from actually being called.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):

https://github.com/typehero/typehero/assets/16005567/b90e04c6-abbc-4e93-857b-c0781a4df08d

