### PR TITLE
chore: refactor type checking

### DIFF
--- a/packages/monaco/src/editor-hooks.ts
+++ b/packages/monaco/src/editor-hooks.ts
@@ -8,11 +8,11 @@ class EditorEvents extends EventTarget {
 
 const event = new EditorEvents();
 type EventNames = 'resetCode';
-export function useResetEditor(deps: unknown[] = []): {
-  subscribe: (eventName: EventNames, cb: () => void) => void;
+export function useResetEditor(): {
+  subscribe: (eventName: EventNames, cb: () => void, deps: unknown[]) => void;
   dispatch: (eventName: EventNames) => void;
 } {
-  function subscribe(eventName: EventNames, cb: () => void) {
+  function subscribe(eventName: EventNames, cb: () => void, deps: unknown[] = []) {
     useEffect(() => {
       const fnc = () => {
         cb();

--- a/packages/monaco/src/editor-hooks.ts
+++ b/packages/monaco/src/editor-hooks.ts
@@ -9,7 +9,7 @@ class EditorEvents extends EventTarget {
 const event = new EditorEvents();
 type EventNames = 'resetCode';
 export function useResetEditor(): {
-  subscribe: (eventName: EventNames, cb: () => void, deps: unknown[]) => void;
+  subscribe: (eventName: EventNames, cb: () => void, deps?: unknown[]) => void;
   dispatch: (eventName: EventNames) => void;
 } {
   function subscribe(eventName: EventNames, cb: () => void, deps: unknown[] = []) {

--- a/packages/monaco/src/utils.ts
+++ b/packages/monaco/src/utils.ts
@@ -1,3 +1,5 @@
+import type * as MonacoEditor from 'monaco-editor';
+
 export function getEventDeltas(e: MouseEvent | TouchEvent, origin: { x: number; y: number }) {
   if (e instanceof MouseEvent) {
     return {
@@ -24,4 +26,35 @@ export function getEventDeltas(e: MouseEvent | TouchEvent, origin: { x: number; 
     currPosX: touch.clientX,
     currPosY: touch.clientY,
   };
+}
+
+export async function typeCheck(monaco: typeof MonacoEditor) {
+  const models = monaco.editor.getModels();
+  const getWorker = await monaco.languages.typescript.getTypeScriptWorker();
+
+  for (const model of models) {
+    const worker = await getWorker(model.uri);
+    const diagnostics = (
+      await Promise.all([
+        worker.getSyntacticDiagnostics(model.uri.toString()),
+        worker.getSemanticDiagnostics(model.uri.toString()),
+      ])
+    ).reduce((a, b) => a.concat(b));
+
+    const markers = diagnostics.map((d) => {
+      const start = model.getPositionAt(d.start!);
+      const end = model.getPositionAt(d.start! + d.length!);
+
+      return {
+        severity: monaco.MarkerSeverity.Error,
+        startLineNumber: start.lineNumber,
+        endLineNumber: end.lineNumber,
+        startColumn: start.column,
+        endColumn: end.column,
+        message: d.messageText as string,
+      } satisfies MonacoEditor.editor.IMarkerData;
+    });
+
+    monaco.editor.setModelMarkers(model, model.getLanguageId(), markers);
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- [x] Moves `typeCheck` into `utils.ts` for shared functionality
- [x] Moves `subscribe` dependencies from root hook

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I moved the `deps` from `useResetEditor` to `subscribe` since they are only used to make sure the callback in that function isn't stale. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested locally by clicking the reset button a bunch of times.

## Screenshots/Video (if applicable):
