### PR TITLE
feat: added beginner & expert in explore

### DIFF
--- a/apps/web/src/app/[locale]/explore/_components/index.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/index.tsx
@@ -38,6 +38,14 @@ export async function Explore() {
       </Suspense>
       <Suspense fallback={<ExploreSectionSkeleton />}>
         <ExploreSection
+          title="Warmup Challenges"
+          fetcher={getChallengesByTagOrDifficulty}
+          tag="BEGINNER"
+          redirectRoute="/explore/beginner"
+        />
+      </Suspense>
+      <Suspense fallback={<ExploreSectionSkeleton />}>
+        <ExploreSection
           title="Great for Beginners"
           fetcher={getChallengesByTagOrDifficulty}
           tag="EASY"
@@ -58,6 +66,14 @@ export async function Explore() {
           fetcher={getChallengesByTagOrDifficulty}
           tag="HARD"
           redirectRoute="/explore/hard"
+        />
+      </Suspense>
+      <Suspense fallback={<ExploreSectionSkeleton />}>
+        <ExploreSection
+          title="For the Masters"
+          fetcher={getChallengesByTagOrDifficulty}
+          tag="EXTREME"
+          redirectRoute="/explore/expert"
         />
       </Suspense>
       <Footsies />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added Begineer & Expert Section in Explore Page

## Related Issue
#675 

## Motivation and Context
There were all the sections, but these two were missing

## How Has This Been Tested?
Yes

## Screenshots/Video (if applicable):
![image](https://github.com/typehero/typehero/assets/50576944/2a8ff209-aa66-467a-aaf1-dda68c6d4aa9)

![image](https://github.com/typehero/typehero/assets/50576944/92c169c2-6326-416b-91eb-d1f9ba28be2b)

Closes #675 