### PR TITLE
Fixed light mode issue with a "No tracks yet " skeleton

### DIFF
--- a/apps/web/src/app/[locale]/tracks/_components/track-enrolled-section.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-enrolled-section.tsx
@@ -15,11 +15,11 @@ const SkeletonTrack = ({ className, ...rest }: HTMLAttributes<HTMLDivElement>) =
     )}
     {...rest}
   >
-    <div className="h-16 w-16 flex-none rounded-2xl bg-white bg-opacity-5" />
+    <div className="h-16 w-16 flex-none rounded-2xl bg-black bg-opacity-5 dark:bg-white dark:bg-opacity-5" />
     <div className="flex-1 space-y-3 pt-1">
-      <div className="h-3 w-2/3 rounded-lg bg-white bg-opacity-5" />
-      <div className="h-2 w-full rounded-lg bg-white bg-opacity-5" />
-      <div className="h-2 w-full rounded-lg bg-white bg-opacity-5" />
+      <div className="h-3 w-2/3 rounded-lg bg-black bg-opacity-5 dark:bg-white  dark:bg-opacity-5" />
+      <div className="h-2 w-full rounded-lg bg-black bg-opacity-5 dark:bg-white  dark:bg-opacity-5 " />
+      <div className="h-2 w-full rounded-lg bg-black  bg-opacity-5 dark:bg-white  dark:bg-opacity-5" />
     </div>
   </Card>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the issue where the skeleton card was not adapting to the lightmode

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #742 

## How Has This Been Tested?
Tested visually

## Screenshots/Video (if applicable):
Before

https://github.com/typehero/typehero/assets/32938743/a046c8c8-5687-49ac-b8cd-6cc22810f517

After

https://github.com/typehero/typehero/assets/32938743/bb8e4038-ce57-4565-8088-17242b1e8cbf

