### PR TITLE
Support deep link to paginated replies

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -343,7 +343,7 @@ function SingleComment({
     const timeout = setTimeout(() => {
       elRef.current?.classList.remove(...SELECTED_CLASSES.split(' '));
     }, 5000);
-    window.requestAnimationFrame(() => elRef.current?.scrollIntoView());
+    window.requestAnimationFrame(() => elRef.current?.scrollIntoView({ block: 'nearest' }));
     return () => {
       clearTimeout(timeout);
     };

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -75,6 +75,8 @@ const commentReportSchema = z
 
 export type CommentReportSchemaType = z.infer<typeof commentReportSchema>;
 
+const REPLIES_PAGESIZE = 5;
+
 // million-ignore
 export function Comment({
   comment,
@@ -86,52 +88,64 @@ export function Comment({
 }: CommentProps) {
   const params = useSearchParams();
   const replyId = params.get('replyId');
-  const [showReplies, setShowReplies] = useState(
-    preselectedCommentMetadata?.selectedComment?.id === comment.id && Boolean(replyId),
-  );
+
+  const hasPreselectedReply =
+    preselectedCommentMetadata?.selectedComment?.id === comment.id && Boolean(replyId);
+
+  const [showReplies, setShowReplies] = useState(hasPreselectedReply);
 
   const [isReplying, setIsReplying] = useState(false);
   const [replyText, setReplyText] = useState('');
   const queryClient = useQueryClient();
 
-  const replyQueryKey = [`${comment.id}-comment-replies`];
-  const replyQueryPaginateKey = replyQueryKey.concat('paginated');
-  const allReplies = useQuery({
+  const replyQueryKey = [`comment-${comment.id}-replies`];
+
+  const {
+    data: replies,
+    fetchStatus,
+    isLoading: isLoadingReplies,
+  } = useQuery({
     queryKey: replyQueryKey,
     queryFn: () => getAllComments({ rootId, rootType: type, parentId: comment.id }),
     staleTime: 5000,
     enabled: showReplies,
   });
 
-  const { data, fetchNextPage, isFetching, refetch } = useInfiniteQuery({
-    queryKey: replyQueryPaginateKey,
-    queryFn: ({ pageParam = 1 }) => getPaginatedComments(allReplies.data!, pageParam),
-    enabled: Boolean(allReplies.data),
-    getNextPageParam: (_, pages) => pages.length + 1,
+  const {
+    data: paginatedReplies,
+    fetchNextPage,
+    isFetching: isFetchingMoreReplies,
+    hasNextPage: hasMoreReplies,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: [...replyQueryKey, 'paginated'],
+    queryFn: ({ pageParam: cursor = 0 }) => {
+      // `cursor` is the start index of the current page
+
+      let take = REPLIES_PAGESIZE;
+      if (hasPreselectedReply && cursor === 0) {
+        const preselectedReplyIndex = replies!.findIndex((reply) => Number(replyId) === reply.id);
+        take = Math.ceil((preselectedReplyIndex + 1) / REPLIES_PAGESIZE) * REPLIES_PAGESIZE;
+      }
+
+      // `end` is exclusive, and therefore also the next cursor
+      const end = cursor + take;
+
+      return {
+        // if the current page is the last, don't return the next cursor
+        cursor: end < replies!.length ? end : undefined,
+        replies: replies!.slice(cursor, end),
+      };
+    },
+    enabled: Boolean(replies),
+    getNextPageParam: (_, pages) => pages.at(-1)?.cursor,
   });
 
   useEffect(() => {
-    if (allReplies.data) {
+    if (replies) {
       refetch();
     }
-  }, [allReplies.data, refetch]);
-
-  const PAGESIZE = 10;
-
-  function getPaginatedComments(comments: NonNullable<typeof allReplies.data>, page: number) {
-    const totalComments = comments.length;
-    const totalPages = Math.ceil(totalComments / PAGESIZE);
-
-    const start = (page - 1) * PAGESIZE;
-    const end = start + PAGESIZE;
-
-    return {
-      totalComments,
-      totalPages,
-      hasMore: page < totalPages,
-      comments: comments.slice(start, end),
-    };
-  }
+  }, [replies, refetch]);
 
   async function createChallengeCommentReply() {
     try {
@@ -198,34 +212,35 @@ export function Comment({
         </div>
       ) : null}
 
-      {!isFetching && showReplies && data?.pages.at(-1)?.hasMore ? (
-        <Button
-          variant="ghost"
-          className="gap-1 text-xs text-neutral-500 duration-200 hover:text-neutral-400 dark:text-neutral-400 dark:hover:text-neutral-300"
-          onClick={() => fetchNextPage()}
-        >
-          <MoreHorizontal size={24} />
-          Load More
-          <span className="sr-only">Load More</span>
-        </Button>
-      ) : null}
-
-      {allReplies.isLoading && allReplies.fetchStatus !== 'idle' ? <CommentSkeleton /> : null}
+      {isLoadingReplies && fetchStatus !== 'idle' ? <CommentSkeleton /> : null}
       {showReplies ? (
-        <div className="flex flex-col-reverse gap-1 pl-6 pt-1">
-          {data?.pages.flatMap((page) =>
-            page.comments.map((reply) => (
-              // this is a reply
-              <SingleComment
-                comment={reply}
-                isReply
-                key={reply.id}
-                replyQueryKey={replyQueryKey}
-                preselectedCommentMetadata={preselectedCommentMetadata}
-              />
-            )),
-          )}
-        </div>
+        <>
+          <div className="flex flex-col gap-1 pl-6 pt-1">
+            {paginatedReplies?.pages.flatMap((page) =>
+              page.replies.map((reply) => (
+                // this is a reply
+                <SingleComment
+                  comment={reply}
+                  isReply
+                  key={reply.id}
+                  replyQueryKey={replyQueryKey}
+                  preselectedCommentMetadata={preselectedCommentMetadata}
+                />
+              )),
+            )}
+          </div>
+          {hasMoreReplies && !isFetchingMoreReplies ? (
+            <Button
+              variant="ghost"
+              className="gap-1 text-xs text-neutral-500 duration-200 hover:text-neutral-400 dark:text-neutral-400 dark:hover:text-neutral-300"
+              onClick={() => fetchNextPage()}
+            >
+              <MoreHorizontal size={24} />
+              Load More
+              <span className="sr-only">Load More</span>
+            </Button>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -119,8 +119,9 @@ export function Comment({
     refetch,
   } = useInfiniteQuery({
     queryKey: [...replyQueryKey, 'paginated'],
-    queryFn: ({ pageParam: cursor = 0 }) => {
+    queryFn: ({ pageParam = 0 }) => {
       // `cursor` is the start index of the current page
+      const cursor = Number(pageParam);
 
       let take = REPLIES_PAGESIZE;
       if (hasPreselectedReply && cursor === 0) {

--- a/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
@@ -256,7 +256,9 @@ function Pagination({
       </Button>
       {pages.map((page) => (
         <Button
-          className={clsx({ 'border border-black dark:border-white/30 ': page === currentPage })}
+          className={clsx('border-border dark:border-ring border', {
+            'bg-border dark:bg-neutral-700': page === currentPage,
+          })}
           key={`pagination-${page}`}
           onClick={() => onClick(page)}
           variant="ghost"

--- a/apps/web/src/app/[locale]/tracks/_components/track-challenge-card.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-challenge-card.tsx
@@ -131,6 +131,9 @@ export function MockTrackChallenge({ challenge }: { challenge: Challenge }) {
           <Check className="absolute left-1 my-auto h-3 w-3 scale-0 stroke-[4] text-white duration-300 peer-checked:scale-100 dark:text-black" />
           {challenge.name}
         </div>
+        <div className="hidden md:block">
+          <DifficultyBadge difficulty={challenge.difficulty} />
+        </div>
       </div>
     </label>
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 This PR includes the following changes:

 * Update pagination of replies to use a cursor in the `useInfiniteQuery` for replies.
   * This enables increasing the size of the first "page" of replies (replies above the "Load More") to include the deep-linked reply.
 * Adjust `scrollIntoView()` to use the `"nearest"` edge option ([reference](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block)).
   * This prevents a bug where the comment container is shifted "up" when the DOM attempts to scroll the preselected reply into view on first paint. (We can iterate here I'm not in love with it, but as-is this fixes the bug on `main`)
* Adjusted background color of selected page button ([1], [2], [3]) so that it color matches the selected tab in the head of the sidebar ("Description", "Solutions", etc).
  * This was suggested by @PickleNik.
* Replies are now in newest-to-oldest order from server. Clicking "Load More" loads in the next 5 older replies

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #738

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to be able to deep link to a reply (which is a comment on a comment), and scroll to it on page load when someone visits the deep link.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Deep links to replies on non-first pages tested in video below. Also tested the new page button background color in dark mode and light mode at the end of the video.

**Test Steps**

- Add comments to a **Challenge**, so that there are >1 pages
- Add replies to a comment not on the first page, so that there are also >1 pages of replies on a comment
- Click share on one of those replies
- Hard navigate your browser to the share URL

Assertions

- [x] Window scrolls the reply into view
- [x] You do not have to click "Load More" to see the reply


The above test case can be repeated for comments on a **Solution**

## Video

https://github.com/typehero/typehero/assets/7817695/f2b16a99-7f21-49ed-bf2a-89a8bd932c04