### PR TITLE
style: fix bio editor responsiveness

### DIFF
--- a/apps/web/src/app/[locale]/settings/_components/profile.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/profile.tsx
@@ -173,7 +173,7 @@ function ProfileForm({ user }: Props) {
           control={form.control}
           name="bio"
           render={({ field }) => (
-            <FormItem className="h-[300px] w-[600px]">
+            <FormItem className="h-[300px] md:w-[600px]">
               <FormLabel>Bio</FormLabel>
               <RichMarkdownEditor onChange={field.onChange} value={field.value} />
               <FormMessage />


### PR DESCRIPTION
The Bio editor was not responsive and was messing up on the mobile 

## Before 
<img width="1440" alt="Screenshot 2023-10-03 at 7 26 19 PM" src="https://github.com/typehero/typehero/assets/86520455/2adf49ac-a50c-4841-a83a-7a58634bc5bf">

## After 
<img width="1440" alt="Screenshot 2023-10-03 at 7 24 41 PM" src="https://github.com/typehero/typehero/assets/86520455/a63861e4-b3cf-4609-9345-e1d1ce053eac">
