### PR TITLE
fix: react-email script --skip-install

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "dev": "email dev -p 6969 --skip-install",
+    "dev": "email dev -p 6969 --skip-install true",
     "clean": "rm -rf node_modules .react-email",
     "build": "email export"
   },

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -11,7 +11,7 @@
     }
   },
   "scripts": {
-    "dev": "email dev -p 6969",
+    "dev": "email dev -p 6969 --skip-install",
     "clean": "rm -rf node_modules .react-email",
     "build": "email export"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://react.email/docs/cli
`--skip-install ` added this to react-mail script

Closes #
#779 

## How Has This Been Tested?
yarn.lock file was not installed and `pnpm run dev` started server without issue
