### PR TITLE
fix: Dark mode profile bio wrong theme colors

### DIFF
--- a/apps/web/src/components/rich-markdown-editor.tsx
+++ b/apps/web/src/components/rich-markdown-editor.tsx
@@ -38,9 +38,22 @@ export function RichMarkdownEditor({
 
   const { theme } = useTheme();
   useEffect(() => {
-    theme === 'dark'
-      ? document.documentElement.setAttribute('data-color-mode', 'dark')
-      : document.documentElement.setAttribute('data-color-mode', 'light');
+    switch(theme){
+      case 'dark': {
+        document.documentElement.setAttribute('data-color-mode', 'dark');
+        break;
+      }
+
+      case 'light': {
+        document.documentElement.setAttribute('data-color-mode', 'light');
+        break;
+      }
+
+      default: {
+        document.documentElement.setAttribute('data-color-mode', 'system');
+        break;
+      }
+    }
   }, [theme]);
 
   const extraCommands = [...(dismissPreview ? [] : [codePreview, commands.fullscreen])];

--- a/apps/web/src/components/rich-markdown-editor.tsx
+++ b/apps/web/src/components/rich-markdown-editor.tsx
@@ -38,7 +38,7 @@ export function RichMarkdownEditor({
 
   const { theme } = useTheme();
   useEffect(() => {
-    switch(theme){
+    switch (theme) {
       case 'dark': {
         document.documentElement.setAttribute('data-color-mode', 'dark');
         break;


### PR DESCRIPTION
`system` or `undefined` values of theme were not being handled appropriately. Added a switch case to map possible theme values to `data-color-mode` values.

<!--- Provide a general summary of your changes in the Title above -->

## Description
As per [next-theme docs](https://www.npmjs.com/package/next-themes#API) the `defaultTheme` attribute is set to the value `system`. While setting `data-color-mode` in RichMarkdownEditor, this causes it to default to `light` theme for the very first time (when `theme` in localStorage is set to `system`). After switching themes manually, the `theme` value in localStorage resets to either `dark` or `light` causing no further problems.

I resolved it by creating a switch block for setting `data-color-mode` based on `theme` and handling the default case. 

Alternate method: Enforcing a application wide default theme by setting `defaultTheme` attribute in `ThemeProvider`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #772

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#772 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually tested the following conditions:
1. `theme` in localStorage is `system`
2. `theme` in localStorage is `light`
3. `theme` in localStorage is `dark`

## Screenshots/Video (if applicable):'
![System](https://github.com/typehero/typehero/assets/79159341/5ffbefbe-c7b9-4763-b7c6-6ef59b830832)
![Dark](https://github.com/typehero/typehero/assets/79159341/b1c84043-935a-4e7f-b66c-81bdd6a6ca1a)
![Light](https://github.com/typehero/typehero/assets/79159341/0fd76be1-8aaa-4633-bc10-4c0473f65aea)


