### PR TITLE
fix: use flag for report comment icon

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronUp,
   Calendar,
+  Flag,
   Pencil,
   Reply,
   Share,
@@ -490,7 +491,7 @@ function SingleComment({
                 <TooltipTrigger asChild>
                   <ReportDialog triggerAsChild commentId={comment.id} reportType="COMMENT">
                     <Button variant="secondary" size="xs">
-                      <span className="hidden text-[0.8rem] sm:block">Flag</span>
+                      <Flag className="h-3 w-3" />
                       <span className="sr-only">Report this comment</span>
                     </Button>
                   </ReportDialog>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
use lucide `<Flag />` icon for report comment button

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):

|Before|After|
|---|---|
|![image](https://github.com/typehero/typehero/assets/7817695/4894279a-3c4c-4d68-81fe-234e07ea519b)|![image](https://github.com/typehero/typehero/assets/7817695/3a1642f7-a63c-4792-98f5-53c959b0583a)|


