### PR TITLE
feat: add dark style to `secondary` variants

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -474,28 +474,28 @@ function SingleComment({
             ) : null}
             {isAuthor ? (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <CommentDeleteDialog asChild comment={comment}>
+                <CommentDeleteDialog asChild comment={comment}>
+                  <TooltipTrigger asChild>
                     <Button variant="secondary" size="xs">
                       <Trash2 className="h-3 w-3" />
                       <span className="sr-only">Delete this comment</span>
                     </Button>
-                  </CommentDeleteDialog>
-                </TooltipTrigger>
+                  </TooltipTrigger>
+                </CommentDeleteDialog>
                 <TooltipContent>
                   <p>Delete</p>
                 </TooltipContent>
               </Tooltip>
             ) : (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <ReportDialog triggerAsChild commentId={comment.id} reportType="COMMENT">
+                <ReportDialog triggerAsChild commentId={comment.id} reportType="COMMENT">
+                  <TooltipTrigger asChild>
                     <Button variant="secondary" size="xs">
                       <Flag className="h-3 w-3" />
                       <span className="sr-only">Report this comment</span>
                     </Button>
-                  </ReportDialog>
-                </TooltipTrigger>
+                  </TooltipTrigger>
+                </ReportDialog>
                 <TooltipContent>
                   <p>Report</p>
                 </TooltipContent>

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -10,7 +10,7 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary border-transparent text-primary-foreground',
-        secondary: 'bg-secondary border-transparent text-secondary-foreground',
+        secondary: 'bg-secondary border-transparent text-secondary-foreground dark:bg-zinc-700',
         destructive: 'bg-destructive border-transparent text-destructive-foreground',
         outline: 'text-foreground',
       },

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -12,8 +12,9 @@ const buttonVariants = cva(
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 dark:bg-zinc-700 dark:hover:bg-zinc-900',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-zinc-900',
         link: 'underline-offset-4 hover:underline text-primary',
       },
       size: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changelog
 * feat: `dark` background+hover for `"secondary"` and `"outline"` button variants
 * feat: `dark` backround for `"secondary"` badge variant
 * fix: tooltips on comment "Report" and "Delete" action buttons

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
locally in Chrome & Brave, be sure you're in system dark mode

## Screenshots
|New|
|---|
|![image](https://github.com/typehero/typehero/assets/7817695/237e3d0a-8d2c-4f42-b137-a0144a44ec92)|
|![image](https://github.com/typehero/typehero/assets/7817695/e6ed3105-d7b4-459b-823f-77435dc28095)|
|![image](https://github.com/typehero/typehero/assets/7817695/d252ee6d-6e0c-44fa-aa4e-a8d77086fb7e)|
|![image](https://github.com/typehero/typehero/assets/7817695/0693195c-1a96-47c5-9a0f-8076bf58def0)|

## Demo

https://github.com/typehero/typehero/assets/7817695/8088afe3-0cb4-4618-92c1-bcb9879baea9

