### PR TITLE
feat: make tests idempotent and add docs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -113,12 +113,14 @@ jobs:
           path: apps/web/playwright-report/
 
       - name: Save PR number
+        if: always()
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo $PR_NUMBER > prNumber
 
       - name: Upload prNumber
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: prNumber

--- a/LOCAL.md
+++ b/LOCAL.md
@@ -118,6 +118,45 @@ Once the server is running you can seed and sync data
 
 UI Library: [shadcn](https://ui.shadcn.com/)
 
+# Testing
+
+### 1. Install Playwright Dependencies
+
+```
+pnpm test:e2e:install
+```
+
+### 2. Run E2E Tests
+
+You can use the production server or the dev server to run the e2e tests.
+
+> [!WARNING]  
+> The dev server may cause tests to timeout.
+
+### 2.a Production server
+
+Playwright will automatically start the production server
+
+```
+pnpm build && pnpm test:e2e
+```
+
+### 2.b Dev server
+
+Open two separate terminals and run the following commands in each one:
+
+Terminal 1:
+
+```
+pnpm dev
+```
+
+Terminal 2:
+
+```
+pnpm test:e2e
+```
+
 ## FAQ
 
 <details>

--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -25,8 +25,13 @@ setup('authenticate user', async ({ page }) => {
         },
       },
       roles: {
-        create: {
-          role: 'USER',
+        connectOrCreate: {
+          where: {
+            role: 'USER',
+          },
+          create: {
+            role: 'USER',
+          },
         },
       },
       accounts: {

--- a/apps/web/tests/e2e/unauthenticated/challenge.test.ts
+++ b/apps/web/tests/e2e/unauthenticated/challenge.test.ts
@@ -1,9 +1,37 @@
 import { test, expect } from '@playwright/test';
+import { prisma } from '@repo/db';
 
 test.use({ storageState: 'playwright/.auth/unauthenticated.json' });
 
 test('challenge page', async ({ page }) => {
-  await page.goto('/challenge/4');
+  const challengeId = 4;
+
+  // delete replies
+  await prisma.comment.deleteMany({
+    where: {
+      rootChallengeId: challengeId,
+      parentId: {
+        not: null,
+      },
+    },
+  });
+  await prisma.comment.deleteMany({
+    where: {
+      rootChallengeId: challengeId,
+    },
+  });
+  await prisma.sharedSolution.deleteMany({
+    where: {
+      challengeId,
+    },
+  });
+  await prisma.submission.deleteMany({
+    where: {
+      challengeId,
+    },
+  });
+
+  await page.goto(`/challenge/${challengeId}`);
 
   await expect(page.getByRole('heading', { name: 'Pick' })).toBeVisible();
   await expect(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Made tests rerunnable by adding `connectOrCreate` and deleting records
- Added docs to run tests locally
- Fix e2e workflow

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #764 