### PR TITLE
[Feat] :Move react-query logo to top right corner

### DIFF
--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -10,6 +10,7 @@ import { Toolbar } from '~/components/toolbar';
 import { I18nProviderClient } from '~/locales/client';
 import en from '~/locales/en';
 import { FeatureFlagProvider } from './feature-flag-provider';
+import type { Corner } from '@tanstack/react-query-devtools/build/lib/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -18,9 +19,10 @@ interface Props {
 const queryClient = new QueryClient();
 
 export function Providers({ children }: Props) {
+  const position: Corner = 'top-right';
   return (
     <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
+      <ReactQueryDevtools initialIsOpen={false} position={position} />
       <SessionProvider>
         <ThemeProvider attribute="class">
           <FeatureFlagProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move react-query logo to top-right corner
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #794

## Motivation and Context
Logo does not interfere with anything in top-right corner
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
![image](https://github.com/typehero/typehero/assets/72158561/a79aed79-1351-4085-b940-cb93b446a3f3)

