### PR TITLE
fix: make challenge OG description renderable and deterministic

### DIFF
--- a/apps/og-image/app/api/challenge/route.tsx
+++ b/apps/og-image/app/api/challenge/route.tsx
@@ -81,7 +81,7 @@ export async function GET(req: Request) {
               tw="text-7xl font-bold truncate pr-48 -mt-2 overflow-ellipsis"
               style={{ fontWeight: '800 !important' }}
             >
-              {props.title === null ? null : props.title.split(" | ")[0]}
+              {props.title === null ? null : props.title.split(' | ')[0]}
             </h1>
             <p tw="flex items-center -mt-3">
               <p

--- a/apps/og-image/utils/zodParams.ts
+++ b/apps/og-image/utils/zodParams.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-type Primitives = string | number | boolean | null;
-type JsonValue = Primitives | JsonValue[] | { [key: string]: JsonValue };
+type Primitives = boolean | number | string | null;
+type JsonValue = JsonValue[] | Primitives | { [key: string]: JsonValue };
 
 const jsonStr = z.string().transform((str, ctx) => {
   try {
@@ -36,7 +36,7 @@ function truncateWordsFn(str: string, maxCharacters: number) {
   // break at closest word
   const truncated = str.slice(0, maxCharacters);
   const lastSpace = truncated.lastIndexOf(' ');
-  return truncated.slice(0, lastSpace) + ' …';
+  return `${truncated.slice(0, lastSpace)} …`;
 }
 function truncatedWordSchema(opts: { maxCharacters: number }) {
   return z.string().transform((str) => truncateWordsFn(str, opts.maxCharacters));

--- a/apps/web/src/app/[locale]/challenge/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/challenge/[id]/page.tsx
@@ -13,9 +13,11 @@ interface Props {
 
 export async function generateMetadata({ params: { id } }: Props) {
   const challenge = await getChallengeRouteData(id, null);
+  const description = `Unlock your TypeScript potential by solving the ${challenge.name} challenge on TypeHero.`;
+
   return buildMetaForChallenge({
     title: `${challenge.name} | TypeHero`,
-    description: `${challenge.shortDescription}`,
+    description,
     username: challenge.user.name,
     difficulty: challenge.difficulty,
     date: getRelativeTime(challenge.createdAt),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- [x] Removes the markdown from OG descriptions by making it deterministic
- [x] Lints some files

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #819

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Markdown isn't easily rendered in the OG image. I was originally going to take the first sentence of a challenge but this posed a few issues (eg. what if someone doesn't write in full sentences? what if markdown is in the first sentence? etc).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):

<img width="584" alt="image" src="https://github.com/typehero/typehero/assets/16005567/0bb074b0-d8b6-425b-85b3-0360bd28b6de">
