### PR TITLE
fix: validate test and user input in editor before submit

### DIFF
--- a/packages/monaco/src/index.tsx
+++ b/packages/monaco/src/index.tsx
@@ -149,13 +149,20 @@ export function CodePanel(props: CodePanelProps) {
 
             const ts = await (await monaco.languages.typescript.getTypeScriptWorker())(model.uri);
 
-            const errors = await Promise.all([
+            const userErrors = await Promise.all([
               ts.getSemanticDiagnostics(USER_CODE_PATH),
               ts.getSyntacticDiagnostics(USER_CODE_PATH),
               ts.getCompilerOptionsDiagnostics(USER_CODE_PATH),
             ] as const);
 
-            setTsErrors(errors);
+            const testErrors = await Promise.all([
+              ts.getSemanticDiagnostics(TESTS_PATH),
+              ts.getSyntacticDiagnostics(TESTS_PATH),
+              ts.getCompilerOptionsDiagnostics(TESTS_PATH)] as const);
+
+            setTsErrors(testErrors.map((err, i) => {
+              return [...err, ...(userErrors[i] || [])]
+            }) as TsErrors);
 
             monaco.languages.registerInlayHintsProvider(
               'typescript',
@@ -183,13 +190,20 @@ export function CodePanel(props: CodePanelProps) {
 
             const tsWorker = await getTsWorker(mm.uri);
 
-            const errors = await Promise.all([
+            const testErrors = await Promise.all([
               tsWorker.getSemanticDiagnostics(TESTS_PATH),
               tsWorker.getSyntacticDiagnostics(TESTS_PATH),
               tsWorker.getCompilerOptionsDiagnostics(TESTS_PATH),
             ] as const);
 
-            setTsErrors(errors);
+            const userErrors = await Promise.all([
+              tsWorker.getSemanticDiagnostics(USER_CODE_PATH),
+              tsWorker.getSyntacticDiagnostics(USER_CODE_PATH),
+              tsWorker.getCompilerOptionsDiagnostics(USER_CODE_PATH)] as const);
+
+            setTsErrors(testErrors.map((err, i) => {
+              return [...err, ...(userErrors[i] || [])]
+            }) as TsErrors);
           },
         }}
       />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- [x] Add validate user code for both test editor and user editor before submit answer.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #824 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found the related issue. I don't know if it was intentional or not, user can submit the empty answer and save it at the correct  result in the left sidebar in `challenge` page. I checked the code and saw that only the test's editor was validated when user's editor changes. So I tried to add one more validation for user's editor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
<img width="1552" alt="error" src="https://github.com/typehero/typehero/assets/58554582/ef88b358-0697-4548-9923-e87f77e2c4eb">

<img width="1552" alt="done" src="https://github.com/typehero/typehero/assets/58554582/64b8b4d3-704d-4731-ab33-7cb1d81867bb">

