### PR TITLE
fix: fix error on deep link to deleted comment

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/getCommentRouteData.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/getCommentRouteData.ts
@@ -55,6 +55,10 @@ export async function getPreselectedCommentMetadata(challengeId: number, comment
   });
 
   const index = challengeComments.findIndex((comment) => comment.id === commentId);
+
+  // this `commentId` couldn't be found (perhaps it was deleted)
+  if (index === -1) return;
+
   const selectedComment = challengeComments[index];
   const page = Math.ceil((index + 1) / PAGESIZE);
 
@@ -88,8 +92,11 @@ export async function getPreselectedSolutionCommentMetadata(
   if (!solution || !solution.solutionComment) return;
 
   const comments = solution.solutionComment;
-
   const index = comments.findIndex((comment) => comment.id === commentId);
+
+  // this `commentId` couldn't be found (perhaps it was deleted)
+  if (index === -1) return;
+
   const selectedComment = comments[index];
   const page = Math.ceil((index + 1) / PAGESIZE);
 

--- a/apps/web/tests/e2e/authenticated/comment.test.ts
+++ b/apps/web/tests/e2e/authenticated/comment.test.ts
@@ -101,7 +101,7 @@ test.describe('create, edit, and delete comments', () => {
   });
 });
 
-test.describe('share comment', () => {
+test.describe('sharing comments', () => {
   const commentNumber = Math.floor(Math.random() * 1000);
   const parentComment = `Here is my comment ${commentNumber}`;
 
@@ -126,5 +126,34 @@ test.describe('share comment', () => {
 
     await page.goto(`${page.url()}/comments/${comment.id}`);
     await expect(page.locator('div[id^=comment]', { hasText: parentComment })).toBeVisible();
+  });
+
+  test('visiting a link to a deleted comment successfully loads page with remaining comments', async ({
+    page,
+  }) => {
+    const commentA = await prisma.comment.create({
+      data: {
+        rootChallengeId: 6,
+        text: 'to be deleted',
+        userId: USER.id,
+      },
+    });
+
+    await prisma.comment.create({
+      data: {
+        rootChallengeId: 6,
+        text: 'this comment is timeless',
+        userId: USER.id,
+      },
+    });
+
+    // delete comment A
+    await prisma.comment.delete({ where: { id: commentA.id } });
+    // but visit a deep link to it anyway
+    await page.goto(`/challenge/6/comments/${commentA.id}`);
+    // assert other comments, such as comment B, are still visible on page load
+    await expect(
+      page.locator('div[id^=comment]', { hasText: 'this comment is timeless' }),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
### Issue

visiting a deep link to a deleted comment renders the challenge page with the comment view open, but stuck in an "broken loading state"

i sus'd an error message in the server output:
```bash
web:dev: Invalid `prisma.comment.findMany()` invocation:
web:dev: 
web:dev: 
web:dev: Error in query graph construction: AssertionError("Invalid value for skip argument: Value can only be positive, found: -10")
web:dev:  X PrismaClientUnknownRequestError: 
web:dev: Invalid `prisma.comment.findMany()` invocation:
web:dev: 
web:dev: 
web:dev: Error in query graph construction: AssertionError("Invalid value for skip argument: Value can only be positive, found: -10")
web:dev:     at async getPaginatedComments (./src/app/[locale]/challenge/_components/comments/getCommentRouteData.ts:125:22)
```

ah-ha, looks like a `prisma.comment.findMany()` with a `{ skip: -10 }`

turns out that `skip` is calculated with an `index * 10`. `index` is calculated with a `comments.findIndex(. . .)`, and when the comment isn't found then `index` is `-1`. 

### Solution

stupid fix, but when we can't find the deep-linked comment id we can just not return pre-selected comment metadata. The client components already handle this case starting at page 0 (first page) with 0 skip.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

### Testing Steps

* comment on a challenge
* click share on the comment to copy the link to clipboard
* delete the comment
* try to visit that link on your clipboard

After this fix, things successfully load.
