### PR TITLE
fix: inherit submission skeleton 

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[id]/submissions/loading.tsx
+++ b/apps/web/src/app/[locale]/challenge/[id]/submissions/loading.tsx
@@ -1,0 +1,1 @@
+export { SubmissionsSkeleton as default } from './[[...catchAll]]/_components/submissions-skeleton';


### PR DESCRIPTION
It was inheriting the loading skeleton from DescriptionSkeleton as the submissions folder did not have any loading.tsx so it looked the nearest loading.tsx which was present in the root folder. Had to put the loading.tsx out of the catch all route cause it renders the DescriptionSkeleton for a split second .

Closes #829

## Video

https://github.com/typehero/typehero/assets/86520455/ba7adfe2-9bf9-4130-9dd1-78d210d93ba9

