### PR TITLE
fix: landing page metadata

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@ import { Analytics } from '@vercel/analytics/react';
 import '../../styles/globals.css';
 
 import { Inter } from 'next/font/google';
-import type { Metadata } from 'next';
 import { Toaster } from '@repo/ui/components/toaster';
 import { Providers } from './providers';
 import { buildMetaForDefault } from '../metadata';
@@ -11,10 +10,6 @@ import { Navigation } from '~/components/navigation';
 import { getStaticParams } from '~/locales/server';
 
 const inter = Inter({ subsets: ['latin'] });
-
-export async function generateMetadata(): Promise<Metadata> {
-  return buildMetaForDefault({});
-}
 
 export function generateStaticParams() {
   return getStaticParams();

--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -1,15 +1,9 @@
-import type { Metadata } from 'next';
 import { Footsies } from '~/components/footsies';
 import { Community } from './_components/community/community';
 import { Features } from './_components/features';
 import { Hero } from './_components/hero';
 import { WaitlistBanner } from './_components/waitlist-banner';
 import { setStaticParamsLocale } from 'next-international/server';
-import { buildMetaForDefault } from '../metadata';
-
-export async function generateMetadata(): Promise<Metadata> {
-  return buildMetaForDefault({});
-}
 
 export default async function Index({ params: { locale } }: { params: { locale: string } }) {
   setStaticParamsLocale(locale);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,3 +1,10 @@
+import type { Metadata } from 'next';
+import { buildMetaForDefault } from './metadata';
+
+export async function generateMetadata(): Promise<Metadata> {
+  return buildMetaForDefault({});
+}
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return children;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
During build, metadata from the landing page is being generated using information from other routes, eventually jumping around between multiple children routes on different build results. This seems to be a bug on Next's end.

One piece of context I'll put here is that the "jumping around" nature of the page it chooses in order to generate the landing page metadata seems to also include the landing page itself, which led me to believe that the problem had been previously solved by some of the first commits. Keep that in mind when debugging locally. 

Also important, the bug is not reproductible in development mode. You'll need to test changes by running and serving a build in order to see the bug occurring.

References to issues that could be related found by @QuiiBz: 
- https://github.com/vercel/next.js/issues/49988

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #859 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- #859
