### PR TITLE
fix typo: GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/new-challenge.yml
@@ -27,8 +27,8 @@ body:
         - Build Built In Utility Types
         - For The Experts
         - JS Built In Methods
-        - Understanding Typescript Syntax
-        - Typescript Foundations(unions|extends|infer|etc)
+        - Understanding TypeScript Syntax
+        - TypeScript Foundations(unions|extends|infer|etc)
   - type: textarea
     id: description
     attributes:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align=center >
-  <img alt="Github" height=20 src="https://img.shields.io/github/stars/typehero/typehero?style=&logo=github&logoColor=white&label=Stars&labelColor=%23111&color=%23111" />
+  <img alt="GitHub" height=20 src="https://img.shields.io/github/stars/typehero/typehero?style=&logo=github&logoColor=white&label=Stars&labelColor=%23111&color=%23111" />
   <a href="https://discord.gg/trashdev" target="_parent">
     <img alt="Discord" height=20 src="https://img.shields.io/discord/796594544980000808?style=&logo=discord&logoColor=white&label=%20&labelColor=%237389D8&color=%237389D8" />
   </a>

--- a/apps/web/src/app/[locale]/_components/feature-card.tsx
+++ b/apps/web/src/app/[locale]/_components/feature-card.tsx
@@ -457,7 +457,7 @@ export function CuratedTracksCard(props: CardProps) {
       >
         <div className="flex w-[69%] items-center justify-between gap-3 rounded-b-lg rounded-t-xl bg-neutral-500/10 p-2 pl-3">
           <span className="flex items-center gap-1 text-xs font-semibold tracking-wide">
-            Typescript Foundations
+            TypeScript Foundations
           </span>
         </div>
         <div className="flex w-[69%] flex-col">

--- a/apps/web/src/app/[locale]/_components/hero.tsx
+++ b/apps/web/src/app/[locale]/_components/hero.tsx
@@ -163,7 +163,7 @@ export async function Hero() {
               <span className="animate-bg-gradient-to-center relative flex items-center bg-gradient-to-r to-70% bg-[length:420%_420%] bg-clip-text bg-right-bottom text-transparent duration-500 group-hover:bg-left-top dark:from-yellow-500 dark:via-white dark:to-[#3178c6]">
                 <Sparkle className="animate-oldstar absolute  -left-1 top-0.5 mr-2 h-5 w-5 translate-x-0.5 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:stroke-yellow-600 dark:duration-500  " />
                 <Sparkle className="animate-newstar mr-2 h-4 w-4 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:fill-[#3178c6] dark:stroke-white dark:duration-500 dark:group-hover:fill-white" />{' '}
-                Star us on Github
+                Star us on GitHub
               </span>
             </div>
           </a>

--- a/apps/web/src/app/[locale]/login/_components/LoginButton.tsx
+++ b/apps/web/src/app/[locale]/login/_components/LoginButton.tsx
@@ -20,7 +20,7 @@ export function LoginButton({ redirectTo }: { redirectTo: string }) {
 
   return (
     <Button disabled={state === 'pending'} variant="outline" onClick={handleSignIn}>
-      Github
+      GitHub
     </Button>
   );
 }

--- a/packages/db/seed/data/tracks.ts
+++ b/packages/db/seed/data/tracks.ts
@@ -2,10 +2,10 @@ export const tracks = [
   {
     name: 'Crafting TypeScript Utility Types',
     description:
-      "This collection guides you through hands-on exercises to recreate Typescript's built-in utility types.",
+      "This collection guides you through hands-on exercises to recreate TypeScript's built-in utility types.",
   },
   {
-    name: 'Typescript Wizardry',
+    name: 'TypeScript Wizardry',
     description:
       "Dive into the elite realm of TypeScript mastery with our 'Pro-Level TypeScript Challenges.' Designed for seasoned professionals, this collection offers a formidable gauntlet of intricate exercises, pushing the boundaries of your TypeScript expertise to the limit.",
   },
@@ -15,13 +15,13 @@ export const tracks = [
       "This collection of challenges equips you to develop and enhance standard JavaScript methods, all while harnessing TypeScript's advanced type system to achieve a fully typesafe developer experience.",
   },
   {
-    name: 'Understanding Typescript Syntax',
+    name: 'Understanding TypeScript Syntax',
     description:
       'A collection of challenging exercises that dive into type annotations, generics, and more to level up your typescript abilities.',
   },
   {
-    name: 'Typescript Foundations',
+    name: 'TypeScript Foundations',
     description:
-      "'Typescript Foundations' is a curated set of challenges designed to build a strong foundation. From basic syntax to advanced concepts, this collection offers hands-on exercises to help you become a TypeScript Hero.",
+      "'TypeScript Foundations' is a curated set of challenges designed to build a strong foundation. From basic syntax to advanced concepts, this collection offers hands-on exercises to help you become a TypeScript Hero.",
   },
 ];


### PR DESCRIPTION
I realize this is a tiny thing but it's the very first thing my eyes read on the landing page so I thought worth a 10 second fix (especially considering the `GitHub` button right below it has it correct).

figured while we're here might as well catch some TypeScript typos as well: if any of these cause a problem we can just drop the commit