### PR TITLE
fix(markdown): remove fixed font-size from inline code

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -78,7 +78,7 @@ export function Markdown({ children, className }: { children: string; className?
               {String(children).replace(/\n$/, '')}
             </SyntaxHighlighter>
           ) : (
-            <code className="rounded-md border border-zinc-300 bg-neutral-200 px-1 py-[0.10rem] font-mono text-xs text-zinc-600 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+            <code className="rounded-md border border-zinc-300 bg-neutral-200 px-1 py-[0.10rem] font-mono text-zinc-600 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
               {children}
             </code>
           );


### PR DESCRIPTION
Closes #886 

## Screenshots/Video (if applicable):
<img width="488" alt="Screenshot 2023-10-18 at 10 55 46 AM" src="https://github.com/typehero/typehero/assets/86520455/024131cf-aa89-4553-a2d7-fc3792b151fb">

