### PR TITLE
fix(web): i18n error on main page

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,6 +8,12 @@ const I18nMiddleware = createI18nMiddleware({
 });
 
 export function middleware(req: NextRequest) {
+  // Ignore requests to the Vercel user metadata endpoint to prevent
+  // i18n locale error extracting the locale as ".well-known"
+  if (req.nextUrl.pathname === '/.well-known/vercel-user-meta') {
+    return new Response(null, { status: 404 })
+  }
+
   const { VERCEL_ENV: vercelEnv, STAGING: staging = false } = process.env;
 
   // skip blocking the request if local or preview or staging
@@ -19,5 +25,5 @@ export function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
+  matcher: ['/((?!api|static|site.webmanifest|_next|favicon.ico|robots.txt).*)'],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(req: NextRequest) {
   // Ignore requests to the Vercel user metadata endpoint to prevent
   // i18n locale error extracting the locale as ".well-known"
   if (req.nextUrl.pathname === '/.well-known/vercel-user-meta') {
-    return new Response(null, { status: 404 })
+    return new Response(null, { status: 404 });
   }
 
   const { VERCEL_ENV: vercelEnv, STAGING: staging = false } = process.env;


### PR DESCRIPTION
Prevent this error when navigating on the main page: ![Screenshot 2023-10-18 at 08 14 52](https://github.com/typehero/typehero/assets/43268759/f31e2e9c-8fad-48d0-9819-35521714e748)

It's caused by the toolbar when authenticating, but Next.js doesn't seem to handle it properly and it's instead executed by our pages, which extracts the locale to be `.well-known` instead of `en`:
![Screenshot 2023-10-18 at 08 04 16](https://github.com/typehero/typehero/assets/43268759/68b17cac-092a-4a8d-971a-1f9e636ed74a)
