### PR TITLE
fix: profile bio width

### DIFF
--- a/apps/web/src/app/[locale]/[username]/_components/dashboard/overview-tab.tsx
+++ b/apps/web/src/app/[locale]/[username]/_components/dashboard/overview-tab.tsx
@@ -19,7 +19,7 @@ export async function OverviewTab({ user }: Props) {
         <CardTitle>Overview</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="w-full text-sm md:w-64 md:text-start">
+        <div className="w-full text-sm">
           {Boolean(hasBio) && <ReactMarkdown>{user.bio}</ReactMarkdown>}
           {Boolean(!hasBio) && (
             <p className="text-muted-foreground">{user.name} does not have a bio.</p>


### PR DESCRIPTION
reproduce on my bio on staging https://staging.typehero.dev/@ayrock-dev

|Before|
|---|
|<img width="350" alt="image" src="https://github.com/typehero/typehero/assets/7817695/0fe9064c-a2bf-4931-a827-f145ee013c75">|

|After||
|---|---|
|<img width="350" alt="image" src="https://github.com/typehero/typehero/assets/7817695/18ccc98c-1bd0-4eae-8f93-ac7067e24cae">|<img width="150" alt="image" src="https://github.com/typehero/typehero/assets/7817695/3ad2b002-c267-47a1-ad67-15c0ae03e603">|