### PR TITLE
feat: Inherited font sizes for challenge prompts

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
@@ -159,7 +159,7 @@ export function Description({ challenge }: Props) {
         </Tooltip>
       </div>
       {/* Challenge Description */}
-      <div className="prose-invert prose-h3:text-xl mt-6 leading-8">
+      <div className="prose-invert prose-h3:text-xl mt-6 text-[13px] leading-6">
         <Markdown>{challenge.description}</Markdown>
       </div>
     </div>

--- a/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
@@ -159,7 +159,7 @@ export function Description({ challenge }: Props) {
         </Tooltip>
       </div>
       {/* Challenge Description */}
-      <div className="prose-invert prose-h3:text-xl mt-6 text-[13px] leading-6">
+      <div className="prose-invert prose-h3:text-xl mt-6 leading-6">
         <Markdown>{challenge.description}</Markdown>
       </div>
     </div>

--- a/packages/monaco/src/settings-store.ts
+++ b/packages/monaco/src/settings-store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export const DEFAULT_SETTINGS = {
-  fontSize: '12',
+  fontSize: '13',
   bindings: 'standard',
   tabSize: '2',
   vimConfig: `" - this is a comment

--- a/packages/monaco/src/settings-store.ts
+++ b/packages/monaco/src/settings-store.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export const DEFAULT_SETTINGS = {
-  fontSize: '13',
+  fontSize: '16',
   bindings: 'standard',
   tabSize: '2',
   vimConfig: `" - this is a comment

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -76,19 +76,6 @@ export function Markdown({ children, className }: { children: string; className?
               customStyle={{ fontSize: 'inherit' }}
               codeTagProps={{
                 style: {
-                  // Default styles
-                  fontFamily:
-                    'Menlo, Monaco, Consolas, "Andale Mono", "Ubuntu Mono", "Courier New", monospace',
-                  color: 'rgb(212, 212, 212)',
-                  textShadow: 'none',
-                  direction: 'ltr',
-                  textAlign: 'left',
-                  whiteSpace: 'pre',
-                  wordSpacing: 'normal',
-                  wordBreak: 'normal',
-                  tabSize: 4,
-                  hyphens: 'none',
-
                   // overrides
                   fontSize: 'inherit',
                   lineHeight: 'inherit',

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -73,6 +73,27 @@ export function Markdown({ children, className }: { children: string; className?
               style={syntaxHighlighterTheme} // theme
               wrapLines
               wrapLongLines
+              customStyle={{ fontSize: 'inherit' }}
+              codeTagProps={{
+                style: {
+                  // Default styles
+                  fontFamily:
+                    'Menlo, Monaco, Consolas, "Andale Mono", "Ubuntu Mono", "Courier New", monospace',
+                  color: 'rgb(212, 212, 212)',
+                  textShadow: 'none',
+                  direction: 'ltr',
+                  textAlign: 'left',
+                  whiteSpace: 'pre',
+                  wordSpacing: 'normal',
+                  wordBreak: 'normal',
+                  tabSize: 4,
+                  hyphens: 'none',
+
+                  // overrides
+                  fontSize: 'inherit',
+                  lineHeight: 'inherit',
+                },
+              }}
               {...props}
             >
               {String(children).replace(/\n$/, '')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the default font size of prompts to 13px and made the font size in the code block inherited

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #944 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#944 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
No

## Screenshots/Video (if applicable):
<img width="1017" alt="Screenshot 2023-10-23 at 23 56 00" src="https://github.com/typehero/typehero/assets/46888096/c0f62a95-58da-494d-b206-ba2a2fb6b4ec">

