### PR TITLE
Feature: 404 page

### DIFF
--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -1,8 +1,39 @@
+'use client';
+
+import { Button } from '@repo/ui/components/button';
+import { useState } from 'react';
+import { BackgroundGrid } from './_components/hero-illustration';
+
 export default function NotFound() {
+  const [randomChallengeSlug, setRandomChallengeSlug] = useState('');
+
   return (
-    <div className="flex h-screen flex-col items-center justify-center">
-      <h1 className="text-4xl font-bold">404</h1>
-      <p className="text-2xl">The page you are looking for is in another castle</p>
+    <div className="flex h-full flex-col items-center justify-center gap-8">
+      <div className="absolute inset-10 -z-30  overflow-hidden rounded-full opacity-70">
+        <BackgroundGrid />
+      </div>
+      <div className="flex flex-col items-center justify-center">
+        <h1 className="font-mono text-9xl font-bold leading-tight md:text-[12rem]">404</h1>
+        <p className=" px-6 text-center font-mono text-base md:px-0 md:text-xl">
+          Looks Like You Took a Wrong Turn at the Interface. <br className="hidden md:inline" />
+        </p>
+      </div>
+      <div className="flex gap-4 ">
+        <a href="/tracks">
+          <Button variant="default" size="lg">
+            Go to tracks
+          </Button>
+        </a>
+        <a href={`/challenge/${randomChallengeSlug}`}>
+          <Button
+            variant="outline"
+            size="lg"
+            className="fancy-border-gradient hover:bg-background relative mx-auto flex gap-4 border-none"
+          >
+            I'm feeling lucky
+          </Button>
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -1,39 +1,50 @@
-'use client';
-
 import { Button } from '@repo/ui/components/button';
-import { useState } from 'react';
 import { BackgroundGrid } from './_components/hero-illustration';
+import { getServerAuthSession } from '@repo/auth/server';
+import { getRandomChallenge } from '~/utils/server/get-random-challenge';
 
-export default function NotFound() {
-  const [randomChallengeSlug, setRandomChallengeSlug] = useState('');
+export default async function NotFound() {
+  const session = await getServerAuthSession();
+  const randomChallengeSlug = await getRandomChallenge(session);
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-8">
-      <div className="absolute inset-10 -z-30  overflow-hidden rounded-full opacity-70">
+      <div className="absolute inset-10 -z-30  overflow-hidden rounded-full opacity-70 lg:hidden">
         <BackgroundGrid />
       </div>
       <div className="flex flex-col items-center justify-center">
         <h1 className="font-mono text-9xl font-bold leading-tight md:text-[12rem]">404</h1>
         <p className=" px-6 text-center font-mono text-base md:px-0 md:text-xl">
           Looks Like You Took a Wrong Turn at the Interface. <br className="hidden md:inline" />
+          Let's Get You Back on Track
         </p>
       </div>
-      <div className="flex gap-4 ">
-        <a href="/tracks">
-          <Button variant="default" size="lg">
-            Go to tracks
-          </Button>
-        </a>
-        <a href={`/challenge/${randomChallengeSlug}`}>
-          <Button
-            variant="outline"
-            size="lg"
-            className="fancy-border-gradient hover:bg-background relative mx-auto flex gap-4 border-none"
-          >
-            I'm feeling lucky
-          </Button>
-        </a>
-      </div>
+      {randomChallengeSlug !== null ? (
+        <div className="flex gap-4 ">
+          <a href="/tracks">
+            <Button variant="default" size="lg">
+              Go to tracks
+            </Button>
+          </a>
+          <a href={`/challenge/${randomChallengeSlug}`}>
+            <Button
+              variant="outline"
+              size="lg"
+              className="fancy-border-gradient hover:bg-background relative mx-auto flex gap-4 border-none"
+            >
+              I'm feeling lucky
+            </Button>
+          </a>
+        </div>
+      ) : (
+        <div>
+          <a href="/">
+            <Button variant="default" size="lg">
+              Go to home
+            </Button>
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -1,11 +1,9 @@
 import { Button } from '@repo/ui/components/button';
 import { BackgroundGrid } from './_components/hero-illustration';
-import { getServerAuthSession } from '@repo/auth/server';
 import { getRandomChallenge } from '~/utils/server/get-random-challenge';
 
 export default async function NotFound() {
-  const session = await getServerAuthSession();
-  const randomChallengeSlug = await getRandomChallenge(session);
+  const randomChallengeSlug = await getRandomChallenge();
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-8">
@@ -21,9 +19,9 @@ export default async function NotFound() {
       </div>
       {randomChallengeSlug !== null ? (
         <div className="flex gap-4 ">
-          <a href="/tracks">
+          <a href="/explore">
             <Button variant="default" size="lg">
-              Go to tracks
+              Go to explore
             </Button>
           </a>
           <a href={`/challenge/${randomChallengeSlug}`}>

--- a/apps/web/src/utils/server/get-random-challenge.ts
+++ b/apps/web/src/utils/server/get-random-challenge.ts
@@ -1,16 +1,11 @@
 'use server';
 import { prisma } from '@repo/db';
-import type { Session } from '@repo/auth/server';
 
 interface resultType {
   slug: string;
 }
 
-export async function getRandomChallenge(session: Session | null) {
-  if (!session) {
-    return null;
-  }
-
+export async function getRandomChallenge() {
   const result: resultType[] =
     await prisma.$queryRaw`SELECT slug FROM Challenge ORDER BY RAND() LIMIT 1`;
 

--- a/apps/web/src/utils/server/get-random-challenge.ts
+++ b/apps/web/src/utils/server/get-random-challenge.ts
@@ -1,0 +1,22 @@
+'use server';
+import { prisma } from '@repo/db';
+import type { Session } from '@repo/auth/server';
+
+interface resultType {
+  slug: string;
+}
+
+export async function getRandomChallenge(session: Session | null) {
+  if (!session) {
+    return null;
+  }
+
+  const result: resultType[] =
+    await prisma.$queryRaw`SELECT slug FROM Challenge ORDER BY RAND() LIMIT 1`;
+
+  if (result.length > 0 && result[0] && Boolean(result[0].slug)) {
+    return result[0].slug;
+  }
+
+  return null;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've made some improvements to the 404 page. The changes cater to both logged-in and logged-out scenarios, providing clear options for users to navigate effectively. 

For logged-in users encountering a 404 page, two buttons are displayed
- Go to tracks: redirects the user to the tracks page
- I'm feeling lucky: redirects the user to a random challenge page which is fetched from the `Challenge` table

For logged-out users encountering a 404 page, one button is displayed
- Go to home: which redirects to the '/' home page

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #940 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
By navigating to an invalid URL

## Screenshots/Video (if applicable):
### Screenshots:

States when the user is not logged in and goes to an invalid URL

![Web capture_23-10-2023_202631_localhost](https://github.com/typehero/typehero/assets/32938743/a9d86402-7784-42c7-84e9-21562169abb3)

![localhost_3000_settingss(iPhone 12 Pro) (1)](https://github.com/typehero/typehero/assets/32938743/f4557c3c-99ec-4d9b-9534-902a9e444142)

States when the user is logged in and navigates to an invalid URL

![Web capture_23-10-2023_20265_localhost](https://github.com/typehero/typehero/assets/32938743/f1b32b39-db13-4619-ac18-769e40af41d5)

![localhost_3000_settingss(iPhone 12 Pro)](https://github.com/typehero/typehero/assets/32938743/5edbdd03-590d-4d44-98ca-92dda19ea334)


### Video:

https://github.com/typehero/typehero/assets/32938743/8c6b521a-27a7-4692-aa0a-51643f6e0350

