### PR TITLE
Added logic to automatically parse url and validate token, also check…

### DIFF
--- a/apps/web/src/app/[locale]/claim/_actions.ts
+++ b/apps/web/src/app/[locale]/claim/_actions.ts
@@ -1,6 +1,5 @@
 'use server';
-
-import { getServerAuthSession } from '@repo/auth/server';
+import { getServerAuthSession, type Session } from '@repo/auth/server';
 import { prisma } from '@repo/db';
 import { redirect } from 'next/navigation';
 import { claimFormSchema } from './_schema';
@@ -28,4 +27,25 @@ export async function validateToken(claimFormData: FormSchema) {
   });
 
   redirect('/explore');
+}
+
+export async function isValidToken(session: Session, claimFormData: FormSchema) {
+  claimFormSchema.parse(claimFormData);
+
+  try {
+    await prisma.betaTokens.update({
+      where: {
+        token: claimFormData.code,
+        AND: {
+          userId: null,
+        },
+      },
+      data: {
+        user: { connect: { id: session?.user.id } },
+      },
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/apps/web/src/app/[locale]/claim/_actions.ts
+++ b/apps/web/src/app/[locale]/claim/_actions.ts
@@ -30,9 +30,9 @@ export async function validateToken(claimFormData: FormSchema) {
 }
 
 export async function isValidToken(session: Session, claimFormData: FormSchema) {
-  claimFormSchema.parse(claimFormData);
-
   try {
+    claimFormSchema.parse(claimFormData);
+
     await prisma.betaTokens.update({
       where: {
         token: claimFormData.code,


### PR DESCRIPTION
This PR adds a strategy for validating a beta token automatically using query params. It also adds a `isBeta` check to make sure a signed in and beta validated user can't access `/claim`

If the user accessed `/claim?token=<token>`:
1. If user is logged in already, we can check if token is valid and redirect appropriately
2. If user is not logged in, send them to login with OAuth and provide callbackUrl=`/claim?token=<token>` and when they get redirected, step 1 will happen.

If token is invalid for any reason, then they will just be shown the `/claim` page for now.


In the video, you will see a user that hasn't signed in yet, enter the url with query param. Then the second attempt is someone who is doing it when they were already logged in. (Keep in mind that I am just mocking the response for validating the token locally. In the second try it should have failed if I use the token again).


https://github.com/typehero/typehero/assets/53154523/7de821c4-94c6-43b7-8c49-435baedb113e


