### PR TITLE
Update Settings/Profile with Small Changes

### DIFF
--- a/apps/web/src/app/[locale]/[username]/_components/dashboard/index.tsx
+++ b/apps/web/src/app/[locale]/[username]/_components/dashboard/index.tsx
@@ -77,7 +77,7 @@ export function Dashboard({ user, isOwnProfile, children }: Props) {
       {/* // TODO: GFI: make each page a subroute, put settings & profile into same layout */}
       <Tabs className="flex flex-col gap-8 py-8 md:flex-row" value={selectedTab}>
         <VerticalTabsList>
-          <div className="flex flex-col items-center gap-10 md:items-start">
+          <div className="flex flex-col items-center gap-4 md:items-start">
             <div
               className="h-32 w-32 rounded-3xl bg-cover bg-center bg-no-repeat md:h-64 md:w-64"
               style={{ backgroundImage: `url(${user.image ?? '/avatar.jpeg'})` }}
@@ -85,7 +85,7 @@ export function Dashboard({ user, isOwnProfile, children }: Props) {
             <div className="flex flex-col items-center gap-2 md:w-full md:items-start">
               <UserHeader user={user} isOwnProfile={isOwnProfile} />
               <span
-                className="text-muted-foreground text-sm italic tracking-tight"
+                className="text-muted-foreground tracking-tight"
                 title={`Joined ${user.createdAt.toString()}`}
               >
                 Joined {getRelativeTime(user.createdAt)}
@@ -97,7 +97,7 @@ export function Dashboard({ user, isOwnProfile, children }: Props) {
                   <div className="flex items-center gap-2" key={link.id}>
                     <MagicIcon url={link.url} />
                     <a
-                      className="text-xs text-neutral-400 hover:text-neutral-600 dark:text-neutral-600 dark:hover:text-neutral-400"
+                      className="text-neutral-400 hover:text-neutral-600 dark:text-neutral-600 dark:hover:text-neutral-400"
                       href={link.url}
                       rel="noopener noreferrer"
                       target="_blank"

--- a/apps/web/src/app/[locale]/settings/_components/edit-profile-tab.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/edit-profile-tab.tsx
@@ -31,9 +31,10 @@ function ProfileForm({ user }: Props) {
   const { toast } = useToast();
 
   // NOTE: make the user links have 4 at all times
+  const userLinksLength: number = user.userLinks?.length ?? 0;
   const userLinks = (user.userLinks = [
     ...user.userLinks,
-    ...Array(4 - user.userLinks.length).fill({
+    ...Array(4 - userLinksLength).fill({
       id: null,
       url: '',
     }),

--- a/apps/web/src/app/[locale]/settings/_components/settings.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/settings.tsx
@@ -32,7 +32,7 @@ export const Settings = async ({ user }: Props) => {
       {/* // TODO: GFI: make each page a subroute, put settings & profile into the same layout */}
       <Tabs className="flex flex-col gap-8 py-8 md:flex-row" defaultValue="settings">
         <VerticalTabsList>
-          <div className="flex flex-col items-center gap-10 md:items-start">
+          <div className="flex flex-col items-center gap-4 md:items-start">
             <div
               className="h-32 w-32 rounded-3xl bg-cover bg-center bg-no-repeat md:h-64 md:w-64"
               style={{ backgroundImage: `url(${user.image ?? '/avatar.jpeg'})` }}

--- a/apps/web/src/app/[locale]/settings/_components/settings.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/settings.tsx
@@ -39,30 +39,7 @@ export const Settings = async ({ user }: Props) => {
             />
             <div className="flex flex-col items-center gap-2 md:w-full md:items-start">
               <UserHeader user={user} isOwnProfile />
-              <span
-                className="text-muted-foreground text-sm italic tracking-tight"
-                title={`Joined ${user.createdAt.toString()}`}
-              >
-                Joined {getRelativeTime(user.createdAt)}
-              </span>
             </div>
-            {Boolean(filteredProfileLinks.length > 0) && (
-              <div className="flex w-full flex-col items-center gap-2 md:items-start">
-                {filteredProfileLinks.map((link) => (
-                  <div className="flex items-center gap-2" key={link.id}>
-                    <MagicIcon url={link.url} />
-                    <a
-                      className="text-xs text-neutral-400 hover:text-neutral-600 dark:text-neutral-600 dark:hover:text-neutral-400"
-                      href={link.url}
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      {stripProtocolAndWWW(link.url)}
-                    </a>
-                  </div>
-                ))}
-              </div>
-            )}
             <div className="flex gap-4 md:w-full md:flex-col">
               <VerticalTabsTrigger
                 className="flex items-center justify-center gap-3 px-2 hover:bg-neutral-200/50 dark:hover:bg-neutral-700/50 md:justify-normal md:px-3 "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removes the links from the settings page because they're un-needed
- Add null check for user links length
- Equal alignment of profile items on left side

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Working on this with Trash when deploying to prod and we saw some visual issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Visually w/ CSS and Browser

## Screenshots/Video (if applicable):

Settings (without links and equal gap with profile)

<img width="1424" alt="image" src="https://github.com/typehero/typehero/assets/44373521/9e338fe1-0646-4f37-9d7d-cae00b264932">

Profile (re-alignment with equal gap now):
<img width="1424" alt="image" src="https://github.com/typehero/typehero/assets/44373521/068de5a1-1c58-4e1e-bdbe-ae32846b34a8">
