### PR TITLE
fix(challenge) generic-function-arguments tests

### DIFF
--- a/challenges/generic-function-arguments/metadata.json
+++ b/challenges/generic-function-arguments/metadata.json
@@ -3,5 +3,5 @@
   "label": "Generic Function Arguments",
   "description": "Give generic function types to your functions",
   "difficulty": "beginner",
-  "prerequisites": ["generic-type-arguments"]
+  "prerequisites": ["generic-type-arguments", "literal-types"]
 }

--- a/challenges/generic-function-arguments/tests.ts
+++ b/challenges/generic-function-arguments/tests.ts
@@ -1,4 +1,4 @@
-import { Expect, Equal } from 'type-testing';
+// import { Expect, Equal } from 'type-testing';
 
 /** temporary */
 const expect = <T>(a: T) => ({
@@ -6,24 +6,24 @@ const expect = <T>(a: T) => ({
 });
 
 const identity_string = identity("this is a string");
-expect(identity_string).toEqual("this is a ...");
+expect(identity_string).toEqual("this is a string");
 type test_identity_string = Expect<Equal<
   typeof identity_string,
-  string
+  "this is a string"
 >>;
 
 const identity_number = identity(123.45);
 expect(identity_number).toEqual(123.45);
 type test_identity_number = Expect<Equal<
   typeof identity_number,
-  number
+  123.45
 >>;
 
 const identity_boolean = identity(false);
 expect(identity_boolean).toEqual(false);
 type test_identity_boolean = Expect<Equal<
   typeof identity_boolean,
-  boolean
+  false
 >>;
 
 const strings = ['1', '1', '2', '3', '5'];


### PR DESCRIPTION
I was trying to avoid getting into literal types, but at this point it's easier and (probably appropriate) to just assume that knowledge by the time of this challenge.

## Description
Fixed the tests for `generic-function-arguments`'s `identity` type.

## Related Issue
Closes https://github.com/typehero/typehero/issues/974

## How Has This Been Tested?
manually including the solution.