### PR TITLE
Fix malformed slugs from type-challenges repo

### DIFF
--- a/packages/db/mocks/challenges.mock.ts
+++ b/packages/db/mocks/challenges.mock.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { simpleGit } from 'simple-git';
 import { parse } from 'yaml';
 
-const slugify = (str: string) => str.toLowerCase().replace(/\s/g, '-');
+const slugify = (str: string) => str.toLowerCase().replace(/\s/g, '-').replace(/\./g, '-');
 export interface InfoFile {
   title: string;
   author: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The titles from the https://github.com/type-challenges/type-challenges repo can have "." in the title, causing our slugs to be malformed for valid URLs.

Solved by adding extra regex to our `slugify` function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #971 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To fix our challenge URLs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

In the browser checking (see screenshot)

## Screenshots/Video (if applicable):

<img width="287" alt="image" src="https://github.com/typehero/typehero/assets/44373521/2d081b56-62d6-4f57-8942-6880d4d74ecd">