### PR TITLE
[Feature] challenge(`type-alias`) improves the prompt

### DIFF
--- a/challenges/type-aliases/prompt.md
+++ b/challenges/type-aliases/prompt.md
@@ -85,6 +85,8 @@ If the answer is yes, then you should probably not make an alias for `Rows`. Thi
 
 ## Solving This Challenge
 
-To solve this challenge, make type aliases for `Name`, `Year`, `Payload`, etc. until there are no errors in the tests.
+To solve this challenge, make type aliases for `Name`, `Year`, `Payload`, (and maybe others!) until there are no errors in the tests. You may need to read the tests and create some new type aliases from scratch.
+
+> As you continue your journey with TypeScript (and TypeHero!) you should get into the habit of closely consulting tests as you go. The tests can help you ensure that your implementation is correct, and quite often that means filling in missing pieces in your implementation.
 
 `Name` is started here for you as an example.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves the prompt of the type-alias challenge to signal to users that they might be asked to create a type alias.

## Description
<!--- Describe your changes in detail -->
It may be confusing to see some type aliases pre-created and have some missing.  Indeed, in this specific challenge this is very much intended behavior because we want users to get some on-the-ground experience with writing type-aliases from scratch.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes # https://github.com/typehero/typehero/issues/1031

thanks again @is-it-ayush for bringing this up
