### PR TITLE
Ensure User is the author of a comment before deleting

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
@@ -96,9 +96,10 @@ export async function deleteComment(comment_id: number, author: string) {
     },
   });
 
-  const isAuthorized = isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
+  const isAuthorized =
+    isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
   if (!isAuthorized) {
-    return 'unauthorized';
+    return "unauthorized";
   }
 
   await deleteCommentWithChildren(prisma, rootComment);

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
@@ -89,15 +89,17 @@ export async function deleteComment(comment_id: number, author: string) {
   const session = await getServerAuthSession();
   if (!session?.user.id) return 'unauthorized';
   if (!comment_id) return 'invalid_comment';
-  const isAuthorized = isAdminOrModerator(session) || isAuthor(session, author);
-  if (!isAuthorized) {
-    return 'unauthorized';
-  }
+  
   const rootComment = await prisma.comment.findFirstOrThrow({
     where: {
       id: comment_id,
     },
   });
+
+  const isAuthorized = isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
+  if (!isAuthorized) {
+    return 'unauthorized';
+  }
 
   await deleteCommentWithChildren(prisma, rootComment);
 }

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
@@ -65,9 +65,19 @@ export async function replyComment(comment: CommentToCreate, parentId: number) {
 export async function updateComment(text: string, id: number) {
   const session = await getServerAuthSession();
 
-  if (!session?.user.id) return 'unauthorized';
+  if (!session) return 'unauthorized';
   if (text.length === 0) return 'text_is_empty';
-  if (!session.user.id) return 'unauthorized';
+
+  const comment = await prisma.comment.findFirstOrThrow({
+    where: {
+      id,
+    },
+  });
+
+  const isAuthorized = isAdminOrModerator(session) || isAuthor(session, comment.userId);
+  if (!isAuthorized) {
+    return 'unauthorized';
+  }
 
   return await prisma.comment.update({
     where: {
@@ -85,19 +95,19 @@ export async function updateComment(text: string, id: number) {
  * @param author The ID of the user who authored the comment.
  * @returns 'unauthorized' if the user is not authorized, 'invalid_comment' if the comment ID is not provided, or undefined if the comment is successfully deleted.
  */
-export async function deleteComment(comment_id: number, author: string) {
+export async function deleteComment(comment_id: number) {
   const session = await getServerAuthSession();
-  if (!session?.user.id) return 'unauthorized';
+
+  if (!session) return 'unauthorized';
   if (!comment_id) return 'invalid_comment';
-  
+
   const rootComment = await prisma.comment.findFirstOrThrow({
     where: {
       id: comment_id,
     },
   });
 
-  const isAuthorized =
-    isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
+  const isAuthorized = isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
   if (!isAuthorized) {
     return 'unauthorized';
   }

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
@@ -72,10 +72,10 @@ export async function updateComment(text: string, id: number) {
   return await prisma.comment.update({
     where: {
       id,
+      userId: session.user.id,
     },
     data: {
       text,
-      userId: session.user.id,
     },
   });
 }

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.action.ts
@@ -99,7 +99,7 @@ export async function deleteComment(comment_id: number, author: string) {
   const isAuthorized =
     isAdminOrModerator(session) || isAuthor(session, rootComment.userId);
   if (!isAuthorized) {
-    return "unauthorized";
+    return 'unauthorized';
   }
 
   await deleteCommentWithChildren(prisma, rootComment);

--- a/apps/web/src/app/[locale]/challenge/_components/comments/delete/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/delete/index.tsx
@@ -28,11 +28,16 @@ export function CommentDeleteDialog({
 
   async function handleDeleteComment() {
     try {
-      const res = await deleteComment(comment.id, comment.userId);
+      const res = await deleteComment(comment.id);
       if (res === 'unauthorized') {
         toast({
           title: 'Unauthorized',
           description: <p>You need to be signed in to post a comment.</p>,
+        });
+      } else if (res === 'invalid_comment') {
+        toast({
+          title: 'Invalid Comment',
+          description: 'The comment id is invalid.',
         });
       } else {
         toast({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure User is the author of a comment before deleting

## Related Issue
Closes #1043 

## Motivation and Context
Malicious Users can currently delete other users comments

## How Has This Been Tested?
Manually

![image](https://github.com/typehero/typehero/assets/2927894/0de95d66-eba5-4db2-bacd-b897fa434297)

Simply change the Comment ID in the request payload to any comment ID
