### PR TITLE
Form Message Color Contrast

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -34,6 +34,8 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
 
+    --error-label: 0 84.2% 60.2%;
+
     --ring: 240 5% 64.9%;
 
     --radius: 0.5rem;
@@ -79,6 +81,8 @@
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 85.7% 97.3%;
+
+    --error-label: 0 92.2% 64.9%;
 
     --ring: 240 3.7% 15.9%;
   }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -51,6 +51,9 @@ module.exports = {
           hovered: 'hsl(var(--card-hovered))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        "error-label": {
+          DEFAULT: 'hsl(var(--error-label))',
+        },
 
         'difficulty-beginner': 'hsl(var(--difficulty-beginner) / <alpha-value>)',
         'difficulty-easy': 'hsl(var(--difficulty-easy) / <alpha-value>)',

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -51,7 +51,7 @@ module.exports = {
           hovered: 'hsl(var(--card-hovered))',
           foreground: 'hsl(var(--card-foreground))',
         },
-        "error-label": {
+        'error-label': {
           DEFAULT: 'hsl(var(--error-label))',
         },
 

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -143,7 +143,7 @@ const FormMessage = React.forwardRef<
 
   return (
     <p
-      className={cn('text-destructive text-sm font-medium', className)}
+      className={cn('text-destructive dark:text-error-label text-sm font-medium', className)}
       id={formMessageId}
       ref={ref}
       {...props}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -72,8 +72,6 @@ export function Markdown({ children, className }: { children: string; className?
               className={clsx(className, 'rounded-xl dark:rounded-md')}
               language={match[1]}
               style={syntaxHighlighterTheme} // theme
-              wrapLines
-              wrapLongLines
               customStyle={{ fontSize: 'inherit' }}
               codeTagProps={{
                 style: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This gives the **form message** in `form.tsx` more color contrast. Particularly, the form message when choosing a title for a solution meets a `4.5:1` color contrast ratio in dark mode. It does not meet this ratio for the message when leaving a comment in dark mode. Light mode has it's own issues... Anyone have any thoughts?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1029 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
![1029-1](https://github.com/typehero/typehero/assets/79437064/73b2d096-b9a3-4919-b2bc-ef287ad22ac4)
![1029-2](https://github.com/typehero/typehero/assets/79437064/fa717569-f3a7-4975-bc64-f14696423abd)
