### PR TITLE
feat: Simplify 'Ctrl+S' Functionality in Editor to Prevent Default Save Prompt

### DIFF
--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -93,7 +93,7 @@ export default function SplitEditor({
 
   useEffect(() => {
     const saveHandler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey && e.code === 'KeyS') && (wrapper.current && wrapper.current.contains(document.activeElement))) {
+      if (((e.ctrlKey || e.metaKey) && e.code === 'KeyS') && (wrapper.current && wrapper.current.contains(document.activeElement))) {
         e.preventDefault();
         toast({
           title: 'Saved',

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -91,48 +91,24 @@ export default function SplitEditor({
   const monacoRef = useRef<typeof import('monaco-editor')>();
   const editorRef = useRef<monacoType.editor.IStandaloneCodeEditor>();
 
-  const [isWrapperInnerFocused, setIsWrapperInnerFocused] = useState(false);
-
   useEffect(() => {
-    const focusHandler = () => {
-      setIsWrapperInnerFocused(true);
-    };
-
-    const blurHandler = () => {
-      setIsWrapperInnerFocused(false);
-    };
-
-    wrapper.current?.addEventListener('focus', focusHandler, true);
-    wrapper.current?.addEventListener('blur', blurHandler, true);
-
-    return () => {
-      wrapper.current?.removeEventListener('focus', focusHandler, true);
-      wrapper.current?.removeEventListener('blur', blurHandler, true);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!isWrapperInnerFocused) {
-      return;
-    }
-
     const saveHandler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.code === 'KeyS') {
+      if ((e.ctrlKey && e.code === 'KeyS') && (wrapper.current && wrapper.current.contains(document.activeElement))) {
         e.preventDefault();
         toast({
           title: 'Saved',
           description: 'Your code has been saved',
           duration: 1000,
         });
-        return false;
       }
     };
 
     document.addEventListener('keydown', saveHandler);
+
     return () => {
       document.removeEventListener('keydown', saveHandler);
     };
-  }, [isWrapperInnerFocused]);
+  }, []);
 
   useEffect(() => {
     monacoRef.current = monaco;

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -93,7 +93,12 @@ export default function SplitEditor({
 
   useEffect(() => {
     const saveHandler = (e: KeyboardEvent) => {
-      if (((e.ctrlKey || e.metaKey) && e.code === 'KeyS') && (wrapper.current && wrapper.current.contains(document.activeElement))) {
+      if (
+        (e.ctrlKey || e.metaKey) &&
+        e.code === 'KeyS' &&
+        wrapper.current &&
+        wrapper.current.contains(document.activeElement)
+      ) {
         e.preventDefault();
         toast({
           title: 'Saved',

--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -91,16 +91,15 @@ export default function SplitEditor({
   const monacoRef = useRef<typeof import('monaco-editor')>();
   const editorRef = useRef<monacoType.editor.IStandaloneCodeEditor>();
 
-  const [wrapperFocused, setWrapperFocused] = useState(false);
+  const [isWrapperInnerFocused, setIsWrapperInnerFocused] = useState(false);
 
   useEffect(() => {
-    console.log('setting up focus handlers');
     const focusHandler = () => {
-      setWrapperFocused(true);
+      setIsWrapperInnerFocused(true);
     };
 
     const blurHandler = () => {
-      setWrapperFocused(false);
+      setIsWrapperInnerFocused(false);
     };
 
     wrapper.current?.addEventListener('focus', focusHandler, true);
@@ -113,7 +112,7 @@ export default function SplitEditor({
   }, []);
 
   useEffect(() => {
-    if (!wrapperFocused) {
+    if (!isWrapperInnerFocused) {
       return;
     }
 
@@ -133,7 +132,7 @@ export default function SplitEditor({
     return () => {
       document.removeEventListener('keydown', saveHandler);
     };
-  }, [wrapperFocused]);
+  }, [isWrapperInnerFocused]);
 
   useEffect(() => {
     monacoRef.current = monaco;


### PR DESCRIPTION
- Add a save handler that listens for Ctrl + S key combination and displays a toast notification with the title "Saved" and the description "Your code has been saved" when the current wrapper ref has focus

## Description
Pressing 'Ctrl+S' in the code editor triggers the browser's default save function. This behavior is counterintuitive for users accustomed to IDEs where 'Ctrl+S' typically saves progress within the app or performs another action, such as running tests. Disabling this or binding 'Ctrl+S' to a more useful function, like running tests, would enhance usability.

## Related Issue
Closes [#1050](https://github.com/typehero/typehero/issues/1050)

## Motivation and Context
This change would streamline the coding experience and align the editor's functionality with common developer practices, improving the platform's overall user experience.

## How Has This Been Tested?
Tested locally, I can add more if requested!
[ ] - Need to test mac `cmd+s`

## Screenshots/Video (if applicable):
https://github.com/typehero/typehero/assets/19780885/9e9e9847-6192-4741-800f-6deefc342d04
