### PR TITLE
[Bug]: Challenge OG image does not render correctly on twitter

### DIFF
--- a/apps/og-image/app/api/challenge/route.tsx
+++ b/apps/og-image/app/api/challenge/route.tsx
@@ -57,7 +57,7 @@ export async function GET(req: Request) {
 
   return new ImageResponse(
     (
-      <div tw="bg-black h-full w-full text-white bg-cover flex flex-col pt-10 pb-10 px-16">
+      <div tw="bg-black h-full w-full text-white bg-cover justify-center flex flex-col  pt-10 pb-10 px-16">
         <Grid />
         {mogus_roll === 8 && (
           <img
@@ -67,7 +67,7 @@ export async function GET(req: Request) {
             alt="OG"
           />
         )}
-        <div tw="flex flex-col items-start h-full overflow-hidden rounded-[3.5rem] border-zinc-700 border-2 to-black relative">
+        <div tw="flex items-start min-h-[350px] overflow-hidden rounded-[3.5rem] border-zinc-700 border-2 to-black relative">
           <svg
             // @ts-ignore
             tw="absolute h-full w-full"

--- a/apps/og-image/app/api/challenge/route.tsx
+++ b/apps/og-image/app/api/challenge/route.tsx
@@ -120,7 +120,7 @@ export async function GET(req: Request) {
     ),
     {
       width: 1200,
-      height: 400,
+      height: 600,
       fonts: [
         { name: 'Inter', data: inter900, weight: 900 },
         { name: 'Inter', data: inter700, weight: 700 },


### PR DESCRIPTION
Fixes dimensions of the challenge twitter-card

## Description
Adjust twitter-card OG image

## Related Issue
Closes https://github.com/typehero/typehero/issues/1060

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Needs to be deployed to branch in order to test in twitter

## Screenshots/Video (if applicable):
<img width="1143" alt="Screenshot 2023-11-06 at 19 14 10" src="https://github.com/typehero/typehero/assets/131662061/4a3c7163-972a-463f-8bce-7f5e00db2c1d">
