### PR TITLE
fix(web): i18n locales error due to toolbar

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,7 +52,7 @@
     "million": "2.6.0-beta.12",
     "monaco-vim": "^0.4.0",
     "next": "14.0.1",
-    "next-international": "1.1.2",
+    "next-international": "1.1.4",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-day-picker": "^8.8.0",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,12 +12,15 @@ export function middleware(req: NextRequest) {
   // because it ignores the i18n static params and provides
   // and invalid locale dynamic param
   if (req.nextUrl.pathname === '/.well-known/vercel-user-meta') {
-    return new Response()
+    return new Response();
   }
 
   return I18nMiddleware(req);
 }
 
 export const config = {
-  matcher: ['/.well-known/vercel-user-meta', '/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
+  matcher: [
+    '/.well-known/vercel-user-meta',
+    '/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)',
+  ],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,19 +8,16 @@ const I18nMiddleware = createI18nMiddleware({
 });
 
 export function middleware(req: NextRequest) {
-  // Ignore the request to this endpoint made by the toolbar
-  // because it ignores the i18n static params and provides
-  // and invalid locale dynamic param
-  if (req.nextUrl.pathname === '/.well-known/vercel-user-meta') {
-    return new Response();
+  const { VERCEL_ENV: vercelEnv, STAGING: staging = false } = process.env;
+
+  // skip blocking the request if local or preview or staging
+  if (!vercelEnv || staging) {
+    return I18nMiddleware(req);
   }
 
   return I18nMiddleware(req);
 }
 
 export const config = {
-  matcher: [
-    '/.well-known/vercel-user-meta',
-    '/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)',
-  ],
+  matcher: ['/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,16 +8,16 @@ const I18nMiddleware = createI18nMiddleware({
 });
 
 export function middleware(req: NextRequest) {
-  const { VERCEL_ENV: vercelEnv, STAGING: staging = false } = process.env;
-
-  // skip blocking the request if local or preview or staging
-  if (!vercelEnv || staging) {
-    return I18nMiddleware(req);
+  // Ignore the request to this endpoint made by the toolbar
+  // because it ignores the i18n static params and provides
+  // and invalid locale dynamic param
+  if (req.nextUrl.pathname === '/.well-known/vercel-user-meta') {
+    return new Response()
   }
 
   return I18nMiddleware(req);
 }
 
 export const config = {
-  matcher: ['/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
+  matcher: ['/.well-known/vercel-user-meta', '/((?!api|static|.*\\..*|_next|favicon.ico|robots.txt).*)'],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ importers:
         specifier: 14.0.1
         version: 14.0.1(@babel/core@7.22.10)(react-dom@18.2.0)(react@18.2.0)
       next-international:
-        specifier: 1.1.2
-        version: 1.1.2
+        specifier: 1.1.4
+        version: 1.1.4
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.0.1)(react-dom@18.2.0)(react@18.2.0)
@@ -730,7 +730,7 @@ importers:
     dependencies:
       '@next/eslint-plugin-next':
         specifier: canary
-        version: 13.5.7-canary.35
+        version: 14.0.2-canary.18
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../config-typescript
@@ -742,7 +742,7 @@ importers:
         version: 5.62.0(eslint@8.45.0)(typescript@5.1.6)
       '@vercel/style-guide':
         specifier: ^4.0.2
-        version: 4.0.2(@next/eslint-plugin-next@13.5.7-canary.35)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
+        version: 4.0.2(@next/eslint-plugin-next@14.0.2-canary.18)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
       eslint:
         specifier: ^8.45.0
         version: 8.45.0
@@ -2331,8 +2331,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/eslint-plugin-next@13.5.7-canary.35:
-    resolution: {integrity: sha512-RQ5sKupGSzMEL5S/RlSKC+K8ud9VXpDK+HibbF4KFP1R9ygXlbrmCNKP6YFy2ajHMcrcjmsefni2QZ4mi60wYw==}
+  /@next/eslint-plugin-next@14.0.2-canary.18:
+    resolution: {integrity: sha512-YKTBPd/EkIpAPiogJ0mbCs1e/Sx1OO9vdQxbC3hm/N2IFnnHCTJ/18A/WLtbJvlp1izr2tfM+TZV7F6CiS3v8w==}
     dependencies:
       glob: 7.1.7
     dev: false
@@ -5142,7 +5142,7 @@ packages:
       yoga-wasm-web: 0.3.0
     dev: false
 
-  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@13.5.7-canary.35)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
+  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@14.0.2-canary.18)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -5162,7 +5162,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.10
       '@babel/eslint-parser': 7.22.10(@babel/core@7.22.10)(eslint@8.45.0)
-      '@next/eslint-plugin-next': 13.5.7-canary.35
+      '@next/eslint-plugin-next': 14.0.2-canary.18
       '@rushstack/eslint-patch': 1.3.2
       '@typescript-eslint/eslint-plugin': 5.59.1(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
@@ -9730,8 +9730,8 @@ packages:
     dev: false
     patched: true
 
-  /next-international@1.1.2:
-    resolution: {integrity: sha512-WLWNmKet7Ln7QDzwBrQNOX27R3RPCP+2XhqL9pSo3aKyO/f/N1zX9k7srM1YnPzACUIWUKptYB0teqTaPiIq/g==}
+  /next-international@1.1.4:
+    resolution: {integrity: sha512-peIJXXEC5lM7zZONCgN1uUxCkIHpSW1pZuHoRTp9ND14K7CDdHajDMz9RTxVCmQUGWXSaqruM6XVAuq4d+Gpxg==}
     dependencies:
       client-only: 0.0.1
       international-types: 0.8.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`@vercel/toolbar` makes a call to `/.well-known/vercel-user-meta` which seems to bypass `generateStaticParams` so we get a `.well-known` dynamic locale segment, which doesn't exist.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1064

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- `cd apps/web && vc link`
- `pnpm dev` then navigate to the homepage, there shouldn't be any error logged in the terminal

## Screenshots/Video (if applicable):

UPDATE:
Only bump next-international to include https://github.com/QuiiBz/next-international/pull/252