### PR TITLE
fix: access to user profile sections

### DIFF
--- a/apps/web/src/app/[locale]/[username]/bookmarks/page.tsx
+++ b/apps/web/src/app/[locale]/[username]/bookmarks/page.tsx
@@ -8,6 +8,7 @@ import {
 import { prisma } from '@repo/db';
 import { BookmarksTab } from '../_components/dashboard/bookmarks-tab';
 import { notFound } from 'next/navigation';
+import { getServerAuthSession } from '@repo/auth/server';
 
 interface Props {
   params: {
@@ -16,9 +17,10 @@ interface Props {
 }
 
 export default async function BookmarksPage({ params: { username: usernameFromQuery } }: Props) {
+  const session = await getServerAuthSession();
   const [, username] = decodeURIComponent(usernameFromQuery).split('@');
 
-  if (!username) return notFound();
+  if (!username || session?.user.name !== username) return notFound();
 
   const user = await prisma.user.findFirst({
     where: {

--- a/apps/web/src/app/[locale]/[username]/completed/page.tsx
+++ b/apps/web/src/app/[locale]/[username]/completed/page.tsx
@@ -8,6 +8,7 @@ import {
 import { CompletedTab } from '../_components/dashboard/completed-tab';
 import { notFound } from 'next/navigation';
 import { prisma } from '@repo/db';
+import { getServerAuthSession } from '@repo/auth/server';
 
 interface Props {
   params: {
@@ -16,9 +17,10 @@ interface Props {
 }
 
 export default async function CompletedPage({ params: { username: usernameFromQuery } }: Props) {
+  const session = await getServerAuthSession();
   const [, username] = decodeURIComponent(usernameFromQuery).split('@');
 
-  if (!username) return notFound();
+  if (!username || session?.user.name !== username) return notFound();
 
   const user = await prisma.user.findFirst({
     where: {

--- a/apps/web/src/app/[locale]/[username]/in-progress/page.tsx
+++ b/apps/web/src/app/[locale]/[username]/in-progress/page.tsx
@@ -8,6 +8,7 @@ import {
 import { InProgressTab } from '../_components/dashboard/in-progress-tab';
 import { notFound } from 'next/navigation';
 import { prisma } from '@repo/db';
+import { getServerAuthSession } from '@repo/auth/server';
 
 interface Props {
   params: {
@@ -16,9 +17,10 @@ interface Props {
 }
 
 export default async function InProgressPage({ params: { username: usernameFromQuery } }: Props) {
+  const session = await getServerAuthSession();
   const [, username] = decodeURIComponent(usernameFromQuery).split('@');
 
-  if (!username) return notFound();
+  if (!username || session?.user.name !== username) return notFound();
 
   const user = await prisma.user.findFirst({
     where: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users are able to view other user's completed tracks, bookmarks, and in progress challenges. This makes sure the user must be logged in and match the name
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
