### PR TITLE
fix: explore cards markdown line height fix

### DIFF
--- a/apps/web/src/app/[locale]/explore/_components/explore-card.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-card.tsx
@@ -118,7 +118,7 @@ export function ExploreCard({ challenge }: ExploreCardProps) {
             <RelativeTime date={challenge.updatedAt} />
           </div>
         </div>
-        <CardDescription className="relative h-20 pb-4">
+        <CardDescription className="relative h-20 pb-4 leading-[1.425rem]">
           <div className="pointer-events-none absolute inset-0 h-full w-full shadow-[inset_0_-1.5rem_1rem_-0.5rem_hsl(var(--card))] duration-300 group-hover/card:shadow-[inset_0_-1.5rem_1rem_-0.5rem_hsl(var(--card-hovered))] group-focus:shadow-[inset_0_-1.5rem_1rem_-0.5rem_hsl(var(--card-hovered))]" />
           <Markdown>{challenge.shortDescription}</Markdown>
         </CardDescription>

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -46,7 +46,7 @@ export function Markdown({ children, className }: { children: string; className?
 
   return (
     <ReactMarkdown
-      className={clsx (className, "leading-relaxed")}
+      className={clsx(className, 'leading-relaxed')}
       components={{
         a: ({ className, ...props }) => (
           <a className={clsx(className, 'text-blue-500')} {...props} />

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -46,7 +46,7 @@ export function Markdown({ children, className }: { children: string; className?
 
   return (
     <ReactMarkdown
-      className={className}
+      className={clsx (className, "leading-relaxed")}
       components={{
         a: ({ className, ...props }) => (
           <a className={clsx(className, 'text-blue-500')} {...props} />

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -46,7 +46,7 @@ export function Markdown({ children, className }: { children: string; className?
 
   return (
     <ReactMarkdown
-      className={clsx(className, 'leading-relaxed')}
+      className={className}
       components={{
         a: ({ className, ...props }) => (
           <a className={clsx(className, 'text-blue-500')} {...props} />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
added clsx and leading-loose to increase line-height

## Related Issue
<!--- Please link to the issue here: -->](https://github.com/typehero/typehero/issues/1098)
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
mobile screen:
![image](https://github.com/typehero/typehero/assets/114667178/919eb563-a02f-424c-b1b0-28d8407b78b0)

large screen: 
![image](https://github.com/typehero/typehero/assets/114667178/5574cf9f-0685-4823-bcb4-45e1e1f5ae8a)

PS: is this what was asked?