### PR TITLE
[Feat] Refactor comments CRUD

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
@@ -2,8 +2,6 @@ import { Loader2 } from '@repo/ui/icons';
 import { useSession } from '@repo/auth/react';
 import { useEffect, useRef, useState, type RefObject } from 'react';
 import { Button } from '@repo/ui/components/button';
-import { useToast } from '@repo/ui/components/use-toast';
-import { ToastAction } from '@repo/ui/components/toast';
 import { Textarea } from '@repo/ui/components/textarea';
 import { Markdown } from '@repo/ui/components/markdown';
 import { useForm } from 'react-hook-form';
@@ -21,7 +19,6 @@ interface Props {
 
 export function CommentInput({ mode, onCancel, placeholder, onSubmit, defaultValue }: Props) {
   const { data: session } = useSession();
-  const { toast } = useToast();
   const [commentMode, setCommentMode] = useState<'editor' | 'preview'>('editor');
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment-input.tsx
@@ -14,64 +14,38 @@ import { singleFieldSchema, type SingleFieldSchema } from '~/utils/zodSingleStri
 interface Props {
   mode: 'create' | 'edit' | 'reply';
   onCancel?: () => void;
-  onChange: (text: string) => void;
-  value: string;
   placeholder?: string;
-  onSubmit: () => Promise<void>;
+  onSubmit: (text: string) => Promise<void>;
+  defaultValue?: string;
 }
 
-export function CommentInput({ mode, onCancel, onChange, value, placeholder, onSubmit }: Props) {
+export function CommentInput({ mode, onCancel, placeholder, onSubmit, defaultValue }: Props) {
   const { data: session } = useSession();
   const { toast } = useToast();
   const [commentMode, setCommentMode] = useState<'editor' | 'preview'>('editor');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const form = useForm<SingleFieldSchema>({
     resolver: zodResolver(singleFieldSchema),
-    defaultValues: { text: '' },
+    defaultValues: { text: defaultValue ?? '' },
   });
   const formValid = form.formState.isValid;
-
+  const value = form.watch('text');
   useAutosizeTextArea(textAreaRef, value, commentMode);
 
-  const handleEnterKey = async () => {
-    if (!session?.user) {
-      toast({
-        variant: 'destructive',
-        title: 'You need to be logged in to comment.',
-        action: <ToastAction altText="Dismiss">Dismiss</ToastAction>,
-      });
-
-      return;
-    }
-    setIsSubmitting(true);
-    await onSubmit();
-    setIsSubmitting(false);
-  };
-
-  const submitComment = async () => {
+  const submitComment = async ({ text }: { text: string }) => {
     try {
-      if (!session?.user) {
-        toast({
-          variant: 'destructive',
-          title: 'You need to be logged in to comment.',
-          action: <ToastAction altText="Dismiss">Dismiss</ToastAction>,
-        });
-
-        return;
-      }
-
-      setIsSubmitting(true);
-
-      await onSubmit();
+      await onSubmit(text);
     } catch (e) {
       console.error(e);
     } finally {
-      setIsSubmitting(false);
+      form.reset();
       setCommentMode('editor');
     }
   };
+
+  const isSubmitting = form.formState.isSubmitting;
 
   return (
     <div className="relative flex flex-col">
@@ -89,7 +63,6 @@ export function CommentInput({ mode, onCancel, onChange, value, placeholder, onS
                     className="resize-none border-0 px-3 py-2 focus-visible:ring-0 md:max-h-[calc(100vh_-_232px)]"
                     onChange={(e) => {
                       field.onChange(e);
-                      onChange(e.target.value);
                       form.trigger();
                     }}
                     onKeyDown={(e) => {
@@ -98,7 +71,7 @@ export function CommentInput({ mode, onCancel, onChange, value, placeholder, onS
                         return;
                       }
                       if (e.key === 'Enter' && e.shiftKey) {
-                        form.handleSubmit(handleEnterKey)();
+                        form.handleSubmit(submitComment);
                         e.preventDefault();
                       }
                     }}

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comments.constants.ts
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comments.constants.ts
@@ -1,0 +1,36 @@
+export const sortKeys = [
+  {
+    label: 'Newest Comments',
+    value: 'newest',
+    key: 'createdAt',
+    order: 'desc',
+  },
+  {
+    label: 'Oldest Comments',
+    value: 'oldest',
+    key: 'createdAt',
+    order: 'asc',
+  },
+  {
+    label: 'Most Votes',
+    value: 'votes',
+    key: 'vote',
+    order: 'desc',
+  },
+  {
+    label: 'Most Replies',
+    value: 'replies',
+    key: 'replies',
+    order: 'desc',
+  },
+] as const;
+
+export const commentErrors = {
+  empty: { title: 'Empty Comment', description: 'You cannot post an empty comment.' },
+  unauthorized: { title: 'Unauthorized', description: 'You must be logged in to post a comment.' },
+  unexpected: {
+    title: 'Uh Oh!',
+    description: 'An error occurred while trying to delete the comment.',
+  },
+  invalidId: { title: 'Invalid Comment', description: 'The comment id is invalid.' },
+};

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comments.hooks.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comments.hooks.tsx
@@ -1,0 +1,296 @@
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useReducer } from 'react';
+
+import { commentErrors, sortKeys } from './comments.constants';
+import { getPaginatedComments } from './getCommentRouteData';
+import type { CommentRoot } from '@repo/db/types';
+import {
+  addComment as addCommentAction,
+  deleteComment as deleteCommentAction,
+  replyComment,
+  updateComment as updateCommentAction,
+} from './comment.action';
+import { toast } from '@repo/ui/components/use-toast';
+
+const getRootQueryKey = (rootId: number, type: CommentRoot) =>
+  `${type.toLowerCase()}-${rootId}-comments`;
+
+export type SortItem = (typeof sortKeys)[number];
+
+interface CommentsMeta {
+  page: number;
+  sort: SortItem;
+}
+
+interface DefaultCommentsProps {
+  rootId: number;
+  type: CommentRoot;
+}
+
+interface UseCommentsProps extends DefaultCommentsProps {
+  initialPage?: number;
+}
+
+export function useComments({ type, rootId, initialPage }: UseCommentsProps) {
+  const queryClient = useQueryClient();
+  const [meta, updateMeta] = useReducer(
+    (state: CommentsMeta, action: Partial<CommentsMeta>) => ({ ...state, ...action }),
+    {
+      page: initialPage ?? 1,
+      sort: sortKeys[0],
+    },
+  );
+
+  const getQueryKey = ({ sort, page }: { sort: string; page: number }) => [
+    getRootQueryKey(rootId, type),
+    sort,
+    page,
+  ];
+
+  const { status, data } = useQuery({
+    queryKey: getQueryKey({ sort: meta.sort.value, page: meta.page }),
+    queryFn: () => {
+      return getPaginatedComments({
+        rootId,
+        page: meta.page,
+        rootType: type,
+        sortKey: meta.sort.key,
+        sortOrder: meta.sort.order,
+      });
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 60000, // one minute
+    refetchOnWindowFocus: false,
+  });
+
+  const changePage = (page: number) => {
+    updateMeta({ page });
+  };
+
+  const changeSorting = (sort: string) => {
+    updateMeta({ sort: sortKeys.find((key) => key.value === sort) ?? sortKeys[0], page: 1 });
+  };
+
+  const deleteComment = async (commentId: number) => {
+    try {
+      const res = await deleteCommentAction(commentId);
+      if (res === 'unauthorized') {
+        toast(commentErrors.unauthorized);
+      } else if (res === 'invalid_comment') {
+        toast(commentErrors.invalidId);
+      } else {
+        toast({
+          title: 'Comment Deleted',
+          variant: 'success',
+          description: 'The comment was successfully deleted.',
+        });
+      }
+    } catch (e) {
+      toast({
+        ...commentErrors.unexpected,
+        variant: 'destructive',
+      });
+    } finally {
+      // If the last comment on the page was deleted, we need to go back a page
+      const newPage = data?.comments.length === 1 ? meta.page - 1 : meta.page;
+      changePage(newPage);
+      queryClient.invalidateQueries({
+        queryKey: getQueryKey({ sort: meta.sort.value, page: newPage }),
+      });
+    }
+  };
+
+  const addComment = async (text: string) => {
+    try {
+      const res = await addCommentAction({
+        text,
+        rootId,
+        rootType: type,
+      });
+      if (res === 'text_is_empty') {
+        toast(commentErrors.empty);
+      } else if (res === 'unauthorized') {
+        toast({
+          ...commentErrors.unauthorized,
+          variant: 'destructive',
+        });
+      }
+      const newPage = 1;
+      changePage(newPage);
+      queryClient.invalidateQueries({
+        queryKey: getQueryKey({ sort: meta.sort.value, page: newPage }),
+      });
+    } catch (e) {
+      toast({
+        ...commentErrors.unauthorized,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const updateComment = async (text: string, commentId: number) => {
+    try {
+      const res = await updateCommentAction(text, commentId);
+      if (res === 'text_is_empty') {
+        toast(commentErrors.empty);
+      } else if (res === 'unauthorized') {
+        toast(commentErrors.unauthorized);
+      }
+    } catch (e) {
+      toast({
+        ...commentErrors.unauthorized,
+        variant: 'destructive',
+      });
+    } finally {
+      queryClient.invalidateQueries({
+        queryKey: getQueryKey({ sort: meta.sort.value, page: meta.page }),
+      });
+    }
+  };
+
+  return {
+    data,
+    status,
+    meta,
+    changePage,
+    changeSorting,
+    deleteComment,
+    addComment,
+    updateComment,
+  };
+}
+
+interface UseCommentRepliesProps extends DefaultCommentsProps {
+  parentCommentId: number;
+  enabled: boolean;
+}
+
+const REPLIES_PAGESIZE = 5;
+
+export function useCommentsReplies({
+  rootId,
+  type,
+  parentCommentId,
+  enabled,
+}: UseCommentRepliesProps) {
+  const queryClient = useQueryClient();
+  const rootQueryKey = [getRootQueryKey(rootId, type)];
+  const queryKey = [...rootQueryKey, `comment-${parentCommentId}-replies`];
+
+  const {
+    data,
+    fetchNextPage,
+    isFetching: isFetchingMoreReplies,
+    hasNextPage: hasMoreReplies,
+    status,
+  } = useInfiniteQuery({
+    enabled,
+    placeholderData: keepPreviousData,
+    initialPageParam: 1,
+    queryKey,
+    queryFn: async ({ pageParam }) => {
+      // `page` is the start index of the current page
+      const page = Number(pageParam);
+
+      const comments = await getPaginatedComments({
+        rootId,
+        page,
+        take: REPLIES_PAGESIZE,
+        rootType: type,
+        parentId: parentCommentId,
+      });
+
+      return {
+        // if the current page is the last, don't return the next cursor
+        page: comments.hasMore ? page + 1 : undefined,
+        replies: comments.comments,
+      };
+    },
+    getNextPageParam: (_, pages) => pages.at(-1)?.page,
+  });
+
+  const addReplyComment = async (text: string) => {
+    try {
+      const res = await replyComment(
+        {
+          text,
+          rootId,
+          rootType: type,
+        },
+        parentCommentId,
+      );
+      if (res === 'text_is_empty') {
+        toast(commentErrors.empty);
+      } else if (res === 'unauthorized') {
+        toast(commentErrors.unauthorized);
+      }
+    } catch (e) {
+      toast({
+        ...commentErrors.unauthorized,
+        variant: 'destructive',
+      });
+    } finally {
+      //Invalidate the root query to refetch the comments
+      queryClient.invalidateQueries({ queryKey: rootQueryKey });
+    }
+  };
+
+  const updateReplyComment = async (text: string, commentId: number) => {
+    try {
+      const res = await updateCommentAction(text, commentId);
+      if (res === 'text_is_empty') {
+        toast(commentErrors.empty);
+      } else if (res === 'unauthorized') {
+        toast(commentErrors.unauthorized);
+      }
+      queryClient.invalidateQueries({ queryKey });
+    } catch (e) {
+      toast({
+        ...commentErrors.unauthorized,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const deleteReplyComment = async (commentId: number) => {
+    try {
+      const res = await deleteCommentAction(commentId);
+      if (res === 'unauthorized') {
+        toast(commentErrors.unauthorized);
+      } else if (res === 'invalid_comment') {
+        toast(commentErrors.invalidId);
+      } else {
+        toast({
+          title: 'Comment Deleted',
+          variant: 'success',
+          description: 'The comment was successfully deleted.',
+        });
+      }
+    } catch (e) {
+      toast({
+        ...commentErrors.unexpected,
+        variant: 'destructive',
+      });
+    } finally {
+      //Invalidate the root query to refetch the comments
+      queryClient.invalidateQueries({ queryKey: rootQueryKey });
+    }
+  };
+
+  const showLoadMoreRepliesBtn = hasMoreReplies || isFetchingMoreReplies;
+
+  return {
+    data,
+    status,
+    fetchNextPage,
+    addReplyComment,
+    updateReplyComment,
+    deleteReplyComment,
+    showLoadMoreRepliesBtn,
+  };
+}

--- a/apps/web/src/app/[locale]/challenge/_components/comments/delete/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/delete/index.tsx
@@ -5,59 +5,28 @@ import { Markdown } from '@repo/ui/components/markdown';
 import { TypographyP } from '@repo/ui/components/paragraph';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
 import { TypographyLarge } from '@repo/ui/components/typography/large';
-import { toast } from '@repo/ui/components/use-toast';
-import { useQueryClient } from '@tanstack/react-query';
+
 import { useState } from 'react';
 import { getRelativeTime } from '~/utils/relativeTime';
-import { deleteComment } from '../comment.action';
+
 import { type PaginatedComments } from '../getCommentRouteData';
 
 interface CommentDeleteDialogProps extends DialogTriggerProps {
   comment: PaginatedComments['comments'][number];
-  queryKey?: (number | string)[];
+  deleteComment: (commentId: number) => Promise<void>;
 }
 
 export function CommentDeleteDialog({
   children,
   comment,
-  queryKey,
+  deleteComment,
   ...props
 }: CommentDeleteDialogProps) {
-  const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
 
   async function handleDeleteComment() {
-    try {
-      const res = await deleteComment(comment.id);
-      if (res === 'unauthorized') {
-        toast({
-          title: 'Unauthorized',
-          description: <p>You need to be signed in to post a comment.</p>,
-        });
-      } else if (res === 'invalid_comment') {
-        toast({
-          title: 'Invalid Comment',
-          description: 'The comment id is invalid.',
-        });
-      } else {
-        toast({
-          title: 'Comment Deleted',
-          variant: 'success',
-          description: 'The comment was successfully deleted.',
-        });
-      }
-    } catch (e) {
-      // todo: log on a dump service.
-      console.log(e);
-      toast({
-        title: 'Uh Oh!',
-        variant: 'destructive',
-        description: 'An error occurred while trying to delete the comment.',
-      });
-    } finally {
-      queryClient.invalidateQueries({ queryKey });
-      setIsOpen(!isOpen);
-    }
+    await deleteComment(comment.id);
+    setIsOpen(!isOpen);
   }
 
   return (

--- a/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
@@ -28,7 +28,7 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
   const {
     data,
     addComment,
-    meta,
+    commentsMeta,
     status,
     changePage,
     changeSorting,
@@ -90,7 +90,7 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
           </div>
           {(data?.comments.length ?? 0) > 0 && (
             <SortSelect
-              currentSortKey={meta.sort}
+              currentSortKey={commentsMeta.sort}
               totalSortKeys={sortKeys}
               onValueChange={changeSorting}
             />
@@ -117,7 +117,7 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
           {(data?.totalPages ?? 0) > 1 && (
             <div className="mt-2 flex justify-center">
               <Pagination
-                currentPage={meta.page}
+                currentPage={commentsMeta.page}
                 onClick={handleChangePage}
                 totalPages={data?.totalPages ?? 0}
               />

--- a/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
@@ -1,19 +1,18 @@
 'use client';
 
 import type { CommentRoot } from '@repo/db/types';
-import { toast } from '@repo/ui/components/use-toast';
 import { ChevronDown, MessageCircle } from '@repo/ui/icons';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useRef, useState } from 'react';
 import { Comment } from './comment';
 import { CommentInput } from './comment-input';
 import { CommentSkeleton } from './comment-skeleton';
-import { addComment } from './comment.action';
 import { getPaginatedComments, type PreselectedCommentMetadata } from './getCommentRouteData';
 import NoComments from './nocomments';
 import { Pagination } from '../pagination';
 import { SortSelect } from '../sort-select';
+import { useComments } from './comments.hooks';
+import { sortKeys } from './comments.constants';
 
 interface Props {
   preselectedCommentMetadata?: PreselectedCommentMetadata;
@@ -22,96 +21,30 @@ interface Props {
   type: CommentRoot;
 }
 
-const sortKeys = [
-  {
-    label: 'Newest Comments',
-    value: 'newest',
-    key: 'createdAt',
-    order: 'desc',
-  },
-  {
-    label: 'Oldest Comments',
-    value: 'oldest',
-    key: 'createdAt',
-    order: 'asc',
-  },
-  {
-    label: 'Most Votes',
-    value: 'votes',
-    key: 'vote',
-    order: 'desc',
-  },
-  {
-    label: 'Most Replies',
-    value: 'replies',
-    key: 'replies',
-    order: 'desc',
-  },
-] as const;
-
 // million-ignore
 export function Comments({ preselectedCommentMetadata, rootId, type, expanded = false }: Props) {
   const [showComments, setShowComments] = useState(expanded);
-  const [text, setText] = useState('');
   const commentContainerRef = useRef<HTMLDivElement>(null);
-  const queryClient = useQueryClient();
-  const [page, setPage] = useState(preselectedCommentMetadata?.page ?? 1);
-  const [sortKey, setSortKey] = useState<(typeof sortKeys)[number]>(sortKeys[0]);
-  const queryKey = [`${type.toLowerCase()}-${rootId}-comments`, sortKey.value, page];
-  const { status, data } = useQuery({
-    queryKey,
-    queryFn: () =>
-      getPaginatedComments({
-        rootId,
-        page,
-        rootType: type,
-        sortKey: sortKey.key,
-        sortOrder: sortKey.order,
-      }),
-    staleTime: 60000, // one minute
-    refetchOnWindowFocus: false,
+  const {
+    data,
+    addComment,
+    meta,
+    status,
+    changePage,
+    changeSorting,
+    deleteComment,
+    updateComment,
+  } = useComments({
+    type,
+    rootId,
   });
 
-  async function createChallengeComment() {
-    try {
-      const res = await addComment({
-        text,
-        rootId,
-        rootType: type,
-      });
-      if (res === 'text_is_empty') {
-        toast({
-          title: 'Empty Comment',
-          description: <p>You cannot post an empty comment.</p>,
-        });
-      } else if (res === 'unauthorized') {
-        toast({
-          title: 'Unauthorized',
-          description: <p>You need to be signed in to post a comment.</p>,
-        });
-      }
-      setText('');
-      queryClient.invalidateQueries({ queryKey: [`${type.toLowerCase()}-${rootId}-comments`] });
-    } catch (e) {
-      toast({
-        title: 'Unauthorized',
-        variant: 'destructive',
-        description: <p>You need to be signed in to post a comment.</p>,
-      });
-    }
-  }
-
   const handleChangePage = (page: number) => {
-    setPage(page);
+    changePage(page);
     commentContainerRef.current?.scroll({
       top: 128,
       behavior: 'smooth',
     });
-  };
-
-  const handleValueChange = (value: string) => {
-    setSortKey(sortKeys.find((sk) => sk.value === value) ?? sortKeys[0]);
-    setPage(1);
   };
 
   return (
@@ -133,7 +66,7 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
           <div className="flex items-center gap-2">
             <MessageCircle className="h-5 w-5" />
             Comments
-            {data?.totalComments != null && <span>({data.totalComments})</span>}
+            {data?.totalComments != null ? <span>({data.totalComments})</span> : null}
           </div>
           <ChevronDown
             className={clsx('h-4 w-4 duration-300', {
@@ -153,34 +86,30 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
           ref={commentContainerRef}
         >
           <div className="m-2 mb-4 mt-0">
-            <CommentInput
-              mode="create"
-              onChange={setText}
-              onSubmit={createChallengeComment}
-              value={text}
-            />
+            <CommentInput mode="create" onSubmit={addComment} />
           </div>
           {(data?.comments.length ?? 0) > 0 && (
             <SortSelect
-              currentSortKey={sortKey}
+              currentSortKey={meta.sort}
               totalSortKeys={sortKeys}
-              onValueChange={handleValueChange}
+              onValueChange={changeSorting}
             />
           )}
           {status === 'pending' && <CommentSkeleton />}
           <div className="flex-1">
             {status === 'success' &&
-              (data.comments.length === 0 ? (
+              (data?.comments.length === 0 ? (
                 <NoComments />
               ) : (
-                data.comments.map((comment) => (
+                data?.comments.map((comment) => (
                   <Comment
+                    key={comment.id}
                     preselectedCommentMetadata={preselectedCommentMetadata}
                     comment={comment}
-                    key={comment.id}
-                    queryKey={queryKey}
                     rootId={rootId}
                     type={type}
+                    deleteComment={deleteComment}
+                    updateComment={updateComment}
                   />
                 ))
               ))}
@@ -188,7 +117,7 @@ export function Comments({ preselectedCommentMetadata, rootId, type, expanded = 
           {(data?.totalPages ?? 0) > 1 && (
             <div className="mt-2 flex justify-center">
               <Pagination
-                currentPage={page}
+                currentPage={meta.page}
                 onClick={handleChangePage}
                 totalPages={data?.totalPages ?? 0}
               />


### PR DESCRIPTION
## Description
- fixed https://github.com/typehero/typehero/issues/1095
- Moved comments/replies logic into it's separate hooks
- `CommentsInput` no longer have 2 input values states (external and internal)
- Deleting last comment on 2 (or other page different than 1), not automatically goes back to previous page

## Related Issue
Closes https://github.com/typehero/typehero/issues/1095

## Motivation and Context
This came-up as work trying to fix https://github.com/typehero/typehero/issues/1095. So I decided to refactor it a little bit.
Comments components are kinda mess right now, and full of prop drilling. As a next step I'd love to fix composition over there, so it would be easier to maintain and extend if needed in the future

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
