### PR TITLE
[Fix]: Make homepage static again

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -4,6 +4,11 @@ import { Community } from './_components/community/community';
 import { Features } from './_components/features';
 import { Hero } from './_components/hero';
 import { WaitlistBanner } from './_components/waitlist-banner';
+import { getStaticParams } from '~/locales/server';
+
+export function generateStaticParams() {
+  return getStaticParams();
+}
 
 export default async function Index({ params: { locale } }: { params: { locale: string } }) {
   setStaticParamsLocale(locale);


### PR DESCRIPTION
Adds `getStaticParams` inside `generateStaticParams` to `[locale]/page.tsx` as per https://next-international.vercel.app/docs/app-static-rendering

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):

<img width="609" alt="Screenshot 2023-11-13 at 20 29 02" src="https://github.com/typehero/typehero/assets/131662061/bcdb2c35-7f3c-4ab1-a5f3-5a7dec7584d7">
