### PR TITLE
fix: navigate to second track and you cannot hit the previous button

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/challenge-track-navigation.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/challenge-track-navigation.tsx
@@ -42,17 +42,17 @@ export function ChallengeTrackNavigation({ challenge, track, isCollapsed, classN
   const next = useMemo(() => {
     if (currentIndex === null) return null;
 
-    const index = currentIndex + 1;
-    return index < trackDetails!.trackChallenges.length
-      ? trackDetails!.trackChallenges[index]
+    const nextIndex = currentIndex + 1;
+    return nextIndex < trackDetails!.trackChallenges.length
+      ? trackDetails!.trackChallenges[nextIndex]
       : null;
   }, [currentIndex, trackDetails]);
 
   const previous = useMemo(() => {
     if (currentIndex === null) return null;
 
-    const index = currentIndex - 1;
-    return index > 0 ? trackDetails!.trackChallenges[index] : null;
+    const prevIndex = currentIndex - 1;
+    return prevIndex >= 0 ? trackDetails!.trackChallenges[prevIndex] : null;
   }, [currentIndex, trackDetails]);
 
   if (isPending || track === null || trackDetails === null || trackDetails === undefined)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
made two small changes:
1) In previous index should return the track challenge also if its zero and not just greater than zero
2) named index to prevIndex and nextIndex for better readability  
## Description
<!--- Describe your changes in detail -->
`return index > 0 ? trackDetails!.trackChallenges[index] : null;`
this will return null also if the index is 0 but since indexing starts from 0 
so the code should look like
`return index >= 0 ? trackDetails!.trackChallenges[index] : null;`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/typehero/typehero/issues/1106
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
