### PR TITLE
fix: text selection is invisible

### DIFF
--- a/apps/web/src/app/[locale]/_components/community/community.tsx
+++ b/apps/web/src/app/[locale]/_components/community/community.tsx
@@ -82,7 +82,7 @@ export function Community() {
             <div className="flex flex-1 flex-col items-center gap-6 pb-12 lg:items-start lg:pb-0">
               <div className="rounded-full bg-gradient-to-r from-[#31bdc6] to-[#3178c6] p-[1px] brightness-90 contrast-150 dark:brightness-125 dark:contrast-100">
                 <div className="rounded-full bg-white/80 px-3 py-1 dark:bg-black/80">
-                  <span className="flex items-center bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent select-none">
+                  <span className="flex select-none items-center bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent">
                     <GitBranch className="h-4 w-4 stroke-[#31bdc6] stroke-2 sm:mr-2" />
                     <span className="hidden sm:block">By developers, for developers</span>
                   </span>

--- a/apps/web/src/app/[locale]/_components/community/community.tsx
+++ b/apps/web/src/app/[locale]/_components/community/community.tsx
@@ -82,7 +82,7 @@ export function Community() {
             <div className="flex flex-1 flex-col items-center gap-6 pb-12 lg:items-start lg:pb-0">
               <div className="rounded-full bg-gradient-to-r from-[#31bdc6] to-[#3178c6] p-[1px] brightness-90 contrast-150 dark:brightness-125 dark:contrast-100">
                 <div className="rounded-full bg-white/80 px-3 py-1 dark:bg-black/80">
-                  <span className="flex items-center bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent">
+                  <span className="flex items-center bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent select-none">
                     <GitBranch className="h-4 w-4 stroke-[#31bdc6] stroke-2 sm:mr-2" />
                     <span className="hidden sm:block">By developers, for developers</span>
                   </span>

--- a/apps/web/src/app/[locale]/_components/features.tsx
+++ b/apps/web/src/app/[locale]/_components/features.tsx
@@ -34,7 +34,7 @@ export function Features() {
               href="#features"
             >
               <div className="group relative overflow-hidden rounded-full bg-white/80 px-3 py-1 duration-300 hover:pr-9 dark:bg-black/80">
-                <span className="bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent">
+                <span className="bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent select-none">
                   <svg
                     className="mr-1 inline-block h-4 w-4 fill-[#31bdc6]"
                     viewBox="4 4 48 48"

--- a/apps/web/src/app/[locale]/_components/features.tsx
+++ b/apps/web/src/app/[locale]/_components/features.tsx
@@ -34,7 +34,7 @@ export function Features() {
               href="#features"
             >
               <div className="group relative overflow-hidden rounded-full bg-white/80 px-3 py-1 duration-300 hover:pr-9 dark:bg-black/80">
-                <span className="bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent select-none">
+                <span className="select-none bg-gradient-to-r from-[#31bdc6] to-[#3178c6] bg-clip-text text-transparent">
                   <svg
                     className="mr-1 inline-block h-4 w-4 fill-[#31bdc6]"
                     viewBox="4 4 48 48"

--- a/apps/web/src/app/[locale]/_components/hero.tsx
+++ b/apps/web/src/app/[locale]/_components/hero.tsx
@@ -161,7 +161,7 @@ export async function Hero() {
             className="animate-bg-gradient-to-center group rounded-full bg-gradient-to-r from-yellow-600 via-[#3178c6] to-[#3178c6] to-70% bg-[length:420%_420%] bg-right-bottom p-[1px] brightness-90 contrast-150 duration-500 hover:bg-left-top hover:shadow-[0_0_2rem_-0.5rem_#3178c6] dark:from-yellow-500 dark:via-white dark:to-[#3178c6] dark:brightness-125 dark:contrast-100 dark:hover:shadow-[0_0_2rem_-0.5rem_#fff8]"
           >
             <div className="rounded-full bg-white/80 px-3 py-1 dark:bg-black/80">
-              <span className="animate-bg-gradient-to-center relative flex items-center bg-gradient-to-r to-70% bg-[length:420%_420%] bg-clip-text bg-right-bottom text-transparent duration-500 group-hover:bg-left-top dark:from-yellow-500 dark:via-white dark:to-[#3178c6]">
+              <span className="animate-bg-gradient-to-center relative flex items-center bg-gradient-to-r to-70% bg-[length:420%_420%] bg-clip-text bg-right-bottom text-transparent select-none duration-500 group-hover:bg-left-top dark:from-yellow-500 dark:via-white dark:to-[#3178c6]">
                 <Sparkle className="animate-oldstar absolute  -left-1 top-0.5 mr-2 h-5 w-5 translate-x-0.5 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:stroke-yellow-600 dark:duration-500  " />
                 <Sparkle className="animate-newstar mr-2 h-4 w-4 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:fill-[#3178c6] dark:stroke-white dark:duration-500 dark:group-hover:fill-white" />{' '}
                 Star us on GitHub
@@ -172,7 +172,7 @@ export async function Hero() {
             <div className="absolute left-1/2 top-1/2 -z-10 hidden h-56 w-56 -translate-x-[15%] -translate-y-[50%] rounded-full bg-slate-400/10 blur-3xl dark:block" />
             <div className="absolute right-1/2 top-1/2 -z-10 hidden h-56 w-56 -translate-y-[40%] rounded-full bg-[#3178c6]/20 blur-3xl dark:block" />
             <TypeHeroLogo3D />
-            <h1 className="animate-bg-gradient-to-center-title dark:to-69% bg-gradient-to-br from-[#3178c6] from-[69%] to-black/0 bg-clip-text bg-right-bottom text-6xl font-extrabold text-transparent dark:from-white dark:from-30% dark:via-[#3178c6] dark:to-[#3178c6] dark:bg-[length:300%_300%] sm:text-8xl sm:leading-[5.5rem]">
+            <h1 className="animate-bg-gradient-to-center-title dark:to-69% bg-gradient-to-br from-[#3178c6] from-[69%] to-black/0 bg-clip-text select-none bg-right-bottom text-6xl font-extrabold text-transparent dark:from-white dark:from-30% dark:via-[#3178c6] dark:to-[#3178c6] dark:bg-[length:300%_300%] sm:text-8xl sm:leading-[5.5rem]">
               type
               <br />
               hero

--- a/apps/web/src/app/[locale]/_components/hero.tsx
+++ b/apps/web/src/app/[locale]/_components/hero.tsx
@@ -161,7 +161,7 @@ export async function Hero() {
             className="animate-bg-gradient-to-center group rounded-full bg-gradient-to-r from-yellow-600 via-[#3178c6] to-[#3178c6] to-70% bg-[length:420%_420%] bg-right-bottom p-[1px] brightness-90 contrast-150 duration-500 hover:bg-left-top hover:shadow-[0_0_2rem_-0.5rem_#3178c6] dark:from-yellow-500 dark:via-white dark:to-[#3178c6] dark:brightness-125 dark:contrast-100 dark:hover:shadow-[0_0_2rem_-0.5rem_#fff8]"
           >
             <div className="rounded-full bg-white/80 px-3 py-1 dark:bg-black/80">
-              <span className="animate-bg-gradient-to-center relative flex items-center bg-gradient-to-r to-70% bg-[length:420%_420%] bg-clip-text bg-right-bottom text-transparent select-none duration-500 group-hover:bg-left-top dark:from-yellow-500 dark:via-white dark:to-[#3178c6]">
+              <span className="animate-bg-gradient-to-center relative flex select-none items-center bg-gradient-to-r to-70% bg-[length:420%_420%] bg-clip-text bg-right-bottom text-transparent duration-500 group-hover:bg-left-top dark:from-yellow-500 dark:via-white dark:to-[#3178c6]">
                 <Sparkle className="animate-oldstar absolute  -left-1 top-0.5 mr-2 h-5 w-5 translate-x-0.5 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:stroke-yellow-600 dark:duration-500  " />
                 <Sparkle className="animate-newstar mr-2 h-4 w-4 stroke-[#3178c6] stroke-2 duration-500 group-hover:rotate-180 group-hover:scale-110 group-hover:fill-[#3178c6] dark:stroke-white dark:duration-500 dark:group-hover:fill-white" />{' '}
                 Star us on GitHub
@@ -172,7 +172,7 @@ export async function Hero() {
             <div className="absolute left-1/2 top-1/2 -z-10 hidden h-56 w-56 -translate-x-[15%] -translate-y-[50%] rounded-full bg-slate-400/10 blur-3xl dark:block" />
             <div className="absolute right-1/2 top-1/2 -z-10 hidden h-56 w-56 -translate-y-[40%] rounded-full bg-[#3178c6]/20 blur-3xl dark:block" />
             <TypeHeroLogo3D />
-            <h1 className="animate-bg-gradient-to-center-title dark:to-69% bg-gradient-to-br from-[#3178c6] from-[69%] to-black/0 bg-clip-text select-none bg-right-bottom text-6xl font-extrabold text-transparent dark:from-white dark:from-30% dark:via-[#3178c6] dark:to-[#3178c6] dark:bg-[length:300%_300%] sm:text-8xl sm:leading-[5.5rem]">
+            <h1 className="animate-bg-gradient-to-center-title dark:to-69% select-none bg-gradient-to-br from-[#3178c6] from-[69%] to-black/0 bg-clip-text bg-right-bottom text-6xl font-extrabold text-transparent dark:from-white dark:from-30% dark:via-[#3178c6] dark:to-[#3178c6] dark:bg-[length:300%_300%] sm:text-8xl sm:leading-[5.5rem]">
               type
               <br />
               hero

--- a/apps/web/src/app/[locale]/explore/_components/explore-section.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-section.tsx
@@ -30,13 +30,13 @@ const TITLES_BY_TAG = {
   POPULAR: '',
   NEWEST: '',
   BEGINNER:
-    'bg-clip-text text-transparent bg-gradient-to-r from-sky-500 to-sky-500 dark:from-sky-500 dark:to-sky-200',
-  EASY: 'bg-clip-text text-transparent bg-gradient-to-r from-green-600 to-green-500 dark:from-green-300 dark:to-green-100',
+    'bg-clip-text text-transparent select-none bg-gradient-to-r from-sky-500 to-sky-500 dark:from-sky-500 dark:to-sky-200',
+  EASY: 'bg-clip-text text-transparent select-none bg-gradient-to-r from-green-600 to-green-500 dark:from-green-300 dark:to-green-100',
   MEDIUM:
-    'bg-clip-text text-transparent bg-gradient-to-r from-yellow-600 to-yellow-500 dark:from-yellow-300 dark:to-yellow-100',
-  HARD: 'bg-clip-text text-transparent bg-gradient-to-r from-red-600 to-red-500 dark:from-red-300 dark:to-red-100',
+    'bg-clip-text text-transparent select-none bg-gradient-to-r from-yellow-600 to-yellow-500 dark:from-yellow-300 dark:to-yellow-100',
+  HARD: 'bg-clip-text text-transparent select-none bg-gradient-to-r from-red-600 to-red-500 dark:from-red-300 dark:to-red-100',
   EXTREME:
-    'bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-purple-500 dark:from-purple-400 dark:to-purple-100',
+    'bg-clip-text text-transparent select-none bg-gradient-to-r from-purple-600 to-purple-500 dark:from-purple-400 dark:to-purple-100',
 };
 
 export const COLORS_BY_TAGS = {

--- a/apps/web/src/components/rich-markdown-editor.tsx
+++ b/apps/web/src/components/rich-markdown-editor.tsx
@@ -163,7 +163,7 @@ export function RichMarkdownEditor({
   };
 
   return (
-    <div className="h-full flex-1">
+    <div className="h-full flex-1 selection:text-white selection:bg-blue-400/50">
       <MDEditor
         components={{
           toolbar: (command) => {

--- a/apps/web/src/components/rich-markdown-editor.tsx
+++ b/apps/web/src/components/rich-markdown-editor.tsx
@@ -163,7 +163,7 @@ export function RichMarkdownEditor({
   };
 
   return (
-    <div className="h-full flex-1 selection:text-white selection:bg-blue-400/50">
+    <div className="h-full flex-1 selection:bg-blue-400/50 selection:text-white">
       <MDEditor
         components={{
           toolbar: (command) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes badge text unselectable and resolves the text highlighting issue in the rich markdown editor:
<img width="494" alt="image" src="https://github.com/typehero/typehero/assets/146669165/0e85e69c-394e-4786-bacd-141ed43a9855">

## Related Issue
[https://github.com/typehero/typehero/issues/1097](https://github.com/typehero/typehero/issues/1097)
Closes #1097 

## How Has This Been Tested?
Tested on Firefox

## Screenshots/Video (if applicable):
See related issue and above.