### PR TITLE
fix: challenges count of logged in user is visible in every profile.

### DIFF
--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/challenges-progress.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/challenges-progress.tsx
@@ -5,8 +5,13 @@ import { getSolvedChallenges } from './_actions';
 
 export const DIFFICULTIES = ['BEGINNER', 'EASY', 'MEDIUM', 'HARD', 'EXTREME'] as const;
 
-export async function ChallengesProgress() {
-  const { challenges, percentage, totalChallenges, totalSolved } = await getSolvedChallenges();
+interface ChallengesProgressProps {
+  userId: string;
+}
+
+export async function ChallengesProgress({ userId }: ChallengesProgressProps) {
+  const { challenges, percentage, totalChallenges, totalSolved } =
+    await getSolvedChallenges(userId);
   return (
     <Card className="flex-grow">
       <CardHeader>

--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
@@ -16,7 +16,7 @@ export async function OverviewTab({ user }: Props) {
   return (
     <div className="col-span-4 flex flex-col gap-6 md:min-h-[calc(100vh_-_56px_-_6rem)]">
       <div className="flex flex-col md:flex-row md:gap-6">
-        <ChallengesProgress />
+        <ChallengesProgress userId={user.id} />
         {/* //Todo: Filling with void for now, may put contributions / something else */}
         <div className="max-w-sm flex-grow" />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
challenges count of logged in user is visible in every profile.

## Description
<!--- Describe your changes in detail -->
Previously the logged in user's solved problems count was visible on each profile. 
Now it comes to two fixes, either
1. Make everyone's progress public.
2. Make it private to logged in user's profile only.
Made it public for now. Will change based on the feedback.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
