### PR TITLE
feat: aot track icon

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/suggestions.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/suggestions.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Button } from '@repo/ui/components/button';
-import { ChevronRight, Swords } from '@repo/ui/icons';
+import { ChevronRight, Swords, TreePine } from '@repo/ui/icons';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useMemo } from 'react';
@@ -48,13 +48,16 @@ export function Suggestions({ track, challengeId }: SuggestionsProps) {
       : null;
   }, [currentIndex, trackDetails]);
 
+  const isHolidayTrack = trackDetails?.slug === 'advent-of-typescript-2023';
+  const Icon = isHolidayTrack ? TreePine : Swords;
+
   return (
     <div className="w-full max-w-[1000px] md:py-4 md:pb-8">
       {trackDetails && next ? (
         <>
           <div className="flex items-center justify-between p-3">
             <h3 className="text-foreground/70 flex items-center gap-2 text-lg font-semibold md:text-xl">
-              <Swords size={26} />
+              <Icon size={26} />
               {`Next Up in ${trackDetails?.name}`}
             </h3>
             <Link href={`/tracks/${track}`}>

--- a/apps/web/src/app/[locale]/challenge/_components/challenge-track-navigation.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/challenge-track-navigation.tsx
@@ -10,7 +10,7 @@ import { getTrackDetails } from '~/app/[locale]/tracks/_components/track.action'
 import { Button } from '@repo/ui/components/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
 import { cn } from '@repo/ui/cn';
-import { Swords, ChevronLeft, ChevronRight } from '@repo/ui/icons';
+import { ChevronLeft, ChevronRight, Swords, TreePine } from '@repo/ui/icons';
 
 import { ChallengeTrackOutline } from './challenge-track-outline';
 
@@ -58,6 +58,9 @@ export function ChallengeTrackNavigation({ challenge, track, isCollapsed, classN
   if (isPending || track === null || trackDetails === null || trackDetails === undefined)
     return null;
 
+  const isHolidayTrack = track.slug === 'advent-of-typescript-2023';
+  const Icon = isHolidayTrack ? TreePine : Swords;
+
   return (
     <div
       className={cn(
@@ -78,7 +81,7 @@ export function ChallengeTrackNavigation({ challenge, track, isCollapsed, classN
               isCollapsed,
           })}
         >
-          <Swords className="h-4 w-4 shrink-0" />
+          <Icon className="h-4 w-4 shrink-0" />
           {Boolean(!isCollapsed) && (
             <span className="overflow-hidden text-ellipsis whitespace-nowrap">{track.name}</span>
           )}

--- a/apps/web/src/app/[locale]/tracks/_components/track-card-soon.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-card-soon.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@repo/ui/components/badge';
 import { Card, CardContent } from '@repo/ui/components/card';
-import { Swords } from '@repo/ui/icons';
+import { Swords, TreePine } from '@repo/ui/icons';
 import { clsx } from 'clsx';
 import type { Tracks } from './track-grid';
 
@@ -27,6 +27,9 @@ const EnrolledBadge = ({ text = 'Enrolled' }: { text?: string }) => (
 export function TrackCardSoon({ track }: TrackProps) {
   const isEnrolled = Boolean(track.enrolledUsers?.length);
 
+  const isHolidayTrack = track.slug === 'advent-of-typescript-2023';
+  const Icon = isHolidayTrack ? TreePine : Swords;
+
   return (
     <div className="group">
       <Card
@@ -51,7 +54,7 @@ export function TrackCardSoon({ track }: TrackProps) {
               'flex h-24 w-24 flex-none items-center justify-center rounded-2xl',
             )}
           >
-            <Swords
+            <Icon
               size={50}
               className={clsx(
                 'transition-opacity duration-300',

--- a/apps/web/src/app/[locale]/tracks/_components/track-card.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-card.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@repo/ui/components/badge';
 import { Card, CardContent } from '@repo/ui/components/card';
-import { Swords } from '@repo/ui/icons';
+import { Swords, TreePine } from '@repo/ui/icons';
 import { clsx } from 'clsx';
 import Link from 'next/link';
 import type { Tracks } from './track-grid';
@@ -27,6 +27,9 @@ const EnrolledBadge = ({ text = 'Enrolled' }: { text?: string }) => (
 
 export function TrackCard({ track }: TrackProps) {
   const isEnrolled = Boolean(track.enrolledUsers?.length);
+
+  const isHolidayTrack = track.slug === 'advent-of-typescript-2023';
+  const Icon = isHolidayTrack ? TreePine : Swords;
 
   return (
     <Link href={`/tracks/${track.slug}`} className="group">
@@ -82,7 +85,7 @@ export function TrackCard({ track }: TrackProps) {
               'flex h-24 w-24 flex-none items-center justify-center rounded-2xl',
             )}
           >
-            <Swords
+            <Icon
               size={50}
               className={clsx(
                 'transition-opacity duration-300',

--- a/apps/web/src/app/[locale]/tracks/_components/track-details.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-details.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { Swords } from '@repo/ui/icons';
+import { Swords, TreePine } from '@repo/ui/icons';
 import { clsx } from 'clsx';
 import { ActionButton } from './enroll-button';
 import { TrackChallenge } from './track-challenge-card';
@@ -30,6 +30,9 @@ export async function TrackDetail({ slug }: TrackDetailProps) {
   if (track.isComingSoon || !track.visible) {
     return notFound();
   }
+
+  const isHolidayTrack = track.slug === 'advent-of-typescript-2023';
+  const Icon = isHolidayTrack ? TreePine : Swords;
 
   const trackChallenges = track.trackChallenges ?? [];
   const isEnrolled = Boolean(track.enrolledUsers?.length);
@@ -64,7 +67,7 @@ export async function TrackDetail({ slug }: TrackDetailProps) {
                 'hidden h-24 w-24 flex-none items-center justify-center rounded-2xl sm:flex',
               )}
             >
-              <Swords
+              <Icon
                 size={50}
                 className={clsx(
                   'transition-opacity duration-300',

--- a/packages/ui/src/icons.ts
+++ b/packages/ui/src/icons.ts
@@ -57,6 +57,7 @@ export {
   Swords,
   ThumbsUp,
   Trash2,
+  TreePine,
   TrendingUpIcon,
   Triangle,
   Twitter,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add tree icon for various track iconography. Can replace icon with whatever we want or something better later.

Setting this up as example of reading track slug to show some extra fun visuals.

## Screenshots/Video (if applicable):

|Track Card on `/tracks`|
|---|
|<img width="406" alt="image" src="https://github.com/typehero/typehero/assets/7817695/855acfee-ff16-4bb2-a0cd-961c6636c637">|

|Track Detail|
|---|
|<img width="1141" alt="image" src="https://github.com/typehero/typehero/assets/7817695/bf8c5b39-bbfe-4336-ba14-bccbf8465b88">|

|In-Challenge Track Icon|
|---|
|<img width="746" alt="image" src="https://github.com/typehero/typehero/assets/7817695/1f414f5f-b502-484f-bf86-a2bb7fc5be74">|
