### PR TITLE
fix: no space between last edited at and date in comments

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -296,7 +296,7 @@ function SingleComment({
           <ExpandableContent content={comment.text} />
           {hasBeenEdited ? (
             <div className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs">
-              Last edited at
+              Last edited at {" "}
               {new Intl.DateTimeFormat(undefined, {
                 timeStyle: 'short',
                 dateStyle: 'short',

--- a/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/comment.tsx
@@ -296,7 +296,7 @@ function SingleComment({
           <ExpandableContent content={comment.text} />
           {hasBeenEdited ? (
             <div className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs">
-              Last edited at {" "}
+              Last edited at{' '}
               {new Intl.DateTimeFormat(undefined, {
                 timeStyle: 'short',
                 dateStyle: 'short',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Just added a whitespace
## Description
<!--- Describe your changes in detail -->
could have used padding but for that i would have to wrap the "Last edited at" string into a div, 
just to not increase any code length and to fix the issue in minimum i used a white space........

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/typehero/typehero/issues/1133
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
before:
![image](https://github.com/typehero/typehero/assets/114667178/1d8e2785-7773-4e05-b7ef-d7473ab00ce7)
after:
![image](https://github.com/typehero/typehero/assets/114667178/f1a0858d-c295-49d8-9834-ad1bf2bece30)


