### PR TITLE
Fix typo in contributing readme + remove console log

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Once it is filed:
   as well as possibly other tags (such as `critical`), and the issue will be
   left to be [implemented by someone](#your-first-code-contribution)
 
-### Suggestiong Enhancements
+### Suggesting Enhancements
 
 This section guides you through submitting an enhancement suggestion for
 CONTRIBUTING.md **including completely new features and minor improvements to

--- a/packages/monaco/src/index.tsx
+++ b/packages/monaco/src/index.tsx
@@ -98,7 +98,6 @@ export function CodePanel(props: CodePanelProps) {
     }
   };
   const hasFailingTest = tsErrors?.some((e) => e.length) ?? false;
-  console.count('CodePanel');
 
   return (
     <>


### PR DESCRIPTION
Seems like log was added in https://github.com/typehero/typehero/commit/99681058b8562ab8975d357bfeeec21b1248ccd0 