### PR TITLE
fix(e2e-test): add flaky test (`comment.test.ts`) by adding timeout

### DIFF
--- a/apps/web/tests/e2e/authenticated/comment.test.ts
+++ b/apps/web/tests/e2e/authenticated/comment.test.ts
@@ -97,7 +97,7 @@ test.describe('create, edit, and delete comments', () => {
 
     await expect(
       page.getByLabel('Description').getByText(`${editedParentComment} ${parentCodeText}`),
-    ).not.toBeVisible();
+    ).not.toBeVisible({ timeout: 10000 });
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the previously failing e2e test for comments by adding a timeout. I noticed that the deletion of the comment takes some time to get reflected in the frontend.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1180

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Test runs without failure locally (hopefully also in the CI)

