### PR TITLE
The text color of the solution button should remain white.

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/overview.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/overview.tsx
@@ -88,7 +88,7 @@ export function SubmissionOverview({ submissionId }: Props) {
           {!isAotChallenge && (
             <div>
               <Link
-                className="bg-primary flex h-8 items-center gap-1 rounded-lg px-3 py-2 text-sm"
+                className="bg-primary flex h-8 items-center gap-1 rounded-lg px-3 py-2 text-sm text-white"
                 href={`/challenge/${slug}/solutions`}
               >
                 <Plus size={16} /> Solution


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<img width="742" alt="image" src="https://github.com/typehero/typehero/assets/11494827/8b11518f-a465-49c5-b02b-b23e02e93c48">

The overview page `Solution` button text is not very readable in light mode.

<img width="735" alt="image" src="https://github.com/typehero/typehero/assets/11494827/85efd994-2b76-460e-a957-be10a34a0175">

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
