### PR TITLE
Add Linter Fix Rule to Enable Unused Imports in Lint config

### DIFF
--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/_actions.ts
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/_actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { prisma } from '@repo/db';
-import { auth } from '@repo/auth/server';
 import type { DIFFICULTIES } from './challenges-progress';
 
 export type HistoricalChallenge = Awaited<ReturnType<typeof getChallengeHistoryByCategory>>[0];

--- a/apps/web/src/app/[locale]/_components/hero.tsx
+++ b/apps/web/src/app/[locale]/_components/hero.tsx
@@ -1,4 +1,4 @@
-import { Sparkles, Github, Mail, Sparkle, Twitter, Compass } from '@repo/ui/icons';
+import { Github, Mail, Sparkle, Twitter, Compass } from '@repo/ui/icons';
 import Link from 'next/link';
 import { Balancer } from 'react-wrap-balancer';
 import { Button } from '@repo/ui/components/button';

--- a/apps/web/src/app/[locale]/aot-2023/_components/index.tsx
+++ b/apps/web/src/app/[locale]/aot-2023/_components/index.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 import { getAllFlags } from '~/utils/feature-flags';
 import { About } from './about';
 import { CardGrid } from './card-grid';
-import { Github, Sparkle } from '@repo/ui/icons';
+import { Github } from '@repo/ui/icons';
 import { Button } from '@repo/ui/components/button';
 
 export async function AotLandingPage() {

--- a/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/comments/index.tsx
@@ -7,7 +7,7 @@ import { useRef, useState } from 'react';
 import { Comment } from './comment';
 import { CommentInput } from './comment-input';
 import { CommentSkeleton } from './comment-skeleton';
-import { getPaginatedComments, type PreselectedCommentMetadata } from './getCommentRouteData';
+import { type PreselectedCommentMetadata } from './getCommentRouteData';
 import NoComments from './nocomments';
 import { Pagination } from '../pagination';
 import { SortSelect } from '../sort-select';

--- a/apps/web/src/app/[locale]/explore/_components/explore-card.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-card.tsx
@@ -16,11 +16,9 @@ import {
   Sparkle,
   ThumbsUp,
   Triangle,
-  RectangleVertical,
 } from '@repo/ui/icons';
 import dynamic from 'next/dynamic';
 import type { ExploreChallengeData } from './explore.action';
-import { cn } from '@repo/ui/cn';
 import { HolidayChristmasTree } from './aot-2023-explore-card';
 
 const RelativeTime = dynamic(() => import('./relative-time'), {

--- a/apps/web/src/app/[locale]/providers.tsx
+++ b/apps/web/src/app/[locale]/providers.tsx
@@ -7,7 +7,6 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ThemeProvider } from 'next-themes';
 import React, { Suspense } from 'react';
 import { Toolbar } from '~/components/toolbar';
-import { I18nProviderClient } from '~/locales/client';
 import { FeatureFlagProvider } from '../feature-flag-provider';
 
 interface Props {

--- a/apps/web/src/app/[locale]/tracks/_components/track-challenge-card.tsx
+++ b/apps/web/src/app/[locale]/tracks/_components/track-challenge-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, PieChart, Loader2 } from '@repo/ui/icons';
+import { Check, PieChart } from '@repo/ui/icons';
 import { useIsMobile } from '~/utils/useIsMobile';
 
 import type { Challenge, Submission } from '@repo/db/types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,7 +730,7 @@ importers:
     dependencies:
       '@next/eslint-plugin-next':
         specifier: canary
-        version: 14.0.3-canary.4
+        version: 14.0.4-canary.6
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../config-typescript
@@ -742,7 +742,7 @@ importers:
         version: 5.62.0(eslint@8.45.0)(typescript@5.1.6)
       '@vercel/style-guide':
         specifier: ^4.0.2
-        version: 4.0.2(@next/eslint-plugin-next@14.0.3-canary.4)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
+        version: 4.0.2(@next/eslint-plugin-next@14.0.4-canary.6)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6)
       eslint:
         specifier: ^8.45.0
         version: 8.45.0
@@ -752,6 +752,10 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+    devDependencies:
+      eslint-plugin-unused-imports:
+        specifier: ^3.0.0
+        version: 3.0.0(@typescript-eslint/eslint-plugin@5.59.1)(eslint@8.45.0)
 
   tooling/config-tailwind:
     devDependencies:
@@ -2102,7 +2106,6 @@ packages:
   /@eslint-community/regexpp@4.5.1:
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: false
 
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
@@ -2343,8 +2346,8 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/eslint-plugin-next@14.0.3-canary.4:
-    resolution: {integrity: sha512-N2BBtLnP6n2IiynOIJikkLiAQnnZ7s3sl75cV7TRx9KxuvtJ8KYTqGHoMfisqKb/Ji3Ey4TTCH+65fbRqaZL9w==}
+  /@next/eslint-plugin-next@14.0.4-canary.6:
+    resolution: {integrity: sha512-iHzfPUU5rcTwDIqMTf8GvSlSmqeuIPPa0zgmWJgwdPV2V9WupehiOGelhpO2j2l0qUM2FVB4VyW8BdV40ixe8g==}
     dependencies:
       glob: 7.1.7
     dev: false
@@ -4773,7 +4776,6 @@ packages:
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
-    dev: false
 
   /@types/unist@2.0.7:
     resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
@@ -4809,7 +4811,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/parser@5.62.0(eslint@8.45.0)(typescript@5.1.6):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
@@ -4836,7 +4837,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.1
       '@typescript-eslint/visitor-keys': 5.59.1
-    dev: false
 
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
@@ -4863,12 +4863,10 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/types@5.59.1:
     resolution: {integrity: sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
@@ -4893,7 +4891,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -4933,7 +4930,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/visitor-keys@5.59.1:
     resolution: {integrity: sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==}
@@ -4941,7 +4937,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.1
       eslint-visitor-keys: 3.4.3
-    dev: false
 
   /@typescript-eslint/visitor-keys@5.62.0:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
@@ -5067,7 +5062,7 @@ packages:
       yoga-wasm-web: 0.3.0
     dev: false
 
-  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@14.0.3-canary.4)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
+  /@vercel/style-guide@4.0.2(@next/eslint-plugin-next@14.0.4-canary.6)(eslint@8.45.0)(prettier@3.0.2)(typescript@5.1.6):
     resolution: {integrity: sha512-FroL+oOePzhw7n/I+f7zr4WNroGHT/+2TlW6WH9+CVSjMNsEyu7Qstj2mI5gWIBjT1Y2ZImKPppCzI2cIYmNZw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -5087,7 +5082,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.10
       '@babel/eslint-parser': 7.22.10(@babel/core@7.22.10)(eslint@8.45.0)
-      '@next/eslint-plugin-next': 14.0.3-canary.4
+      '@next/eslint-plugin-next': 14.0.4-canary.6
       '@rushstack/eslint-patch': 1.3.2
       '@typescript-eslint/eslint-plugin': 5.59.1(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 5.62.0(eslint@8.45.0)(typescript@5.1.6)
@@ -7315,6 +7310,26 @@ packages:
       strip-indent: 3.0.0
     dev: false
 
+  /eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@5.59.1)(eslint@8.45.0):
+    resolution: {integrity: sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^6.0.0
+      eslint: ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.59.1(@typescript-eslint/parser@5.62.0)(eslint@8.45.0)(typescript@5.1.6)
+      eslint: 8.45.0
+      eslint-rule-composer: 0.3.0
+    dev: true
+
+  /eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
   /eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -7958,7 +7973,6 @@ packages:
 
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
-    dev: false
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -9590,7 +9604,6 @@ packages:
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: false
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}

--- a/tooling/config-eslint/next.js
+++ b/tooling/config-eslint/next.js
@@ -40,6 +40,7 @@ module.exports = {
   root: true,
   plugins: ['unused-imports'],
   rules: {
+    ...rules,
     'unused-imports/no-unused-imports': 'error',
   },
 };

--- a/tooling/config-eslint/next.js
+++ b/tooling/config-eslint/next.js
@@ -38,5 +38,8 @@ module.exports = {
     tsconfigRootDir: `${__dirname}/tsconfig.json`,
   },
   root: true,
-  rules,
+  plugins: ['unused-imports'],
+  rules: {
+    'unused-imports/no-unused-imports': 'error',
+  },
 };

--- a/tooling/config-eslint/node.js
+++ b/tooling/config-eslint/node.js
@@ -35,12 +35,9 @@ module.exports = {
     project: `${__dirname}/tsconfig.json`,
   },
   root: true,
-  rules,
-  // settings: {
-  //   'import/resolver': {
-  //     typescript: {
-  //       project,
-  //     },
-  //   },
-  // },
+  plugins: ['unused-imports'],
+  rules: {
+    ...rules,
+    'unused-imports/no-unused-imports': 'error',
+  },
 };

--- a/tooling/config-eslint/package.json
+++ b/tooling/config-eslint/package.json
@@ -18,5 +18,8 @@
     "eslint": "^8.45.0",
     "eslint-config-turbo": "^1.10.12",
     "typescript": "^5.1.6"
+  },
+  "devDependencies": {
+    "eslint-plugin-unused-imports": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Description

I added a rule to remove unused imports so this will apply when running `pnpm lint:fix`. I am doing this PR so it doesn't muddy up the `Files changed` section 👍🏻 

https://turbo.build/repo/docs/handbook/linting/eslint - From this documentation, we extend from our global eslint file. So, I made the change here so it will apply to all of our directories in the `apps/` dir that extend it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1163 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Remove unused imports from our repo

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Yes I added an unused import in a random file in `apps/web/` then ran `pnpm lint:fix` and it does properly remove it now.
