### PR TITLE
feat: add countdown to aot-2023

### DIFF
--- a/apps/web/src/app/[locale]/_components/countdown-timer.tsx
+++ b/apps/web/src/app/[locale]/_components/countdown-timer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 const DateCard = ({ date, label }: { date: React.ReactNode; label: string }) => {
   return (
-    <div className="flex flex-col items-center gap-4">
+    <div className="flex select-none flex-col items-center gap-4">
       <div className="flex aspect-square w-[60px] items-center justify-center rounded-xl border bg-white/90 p-2 text-3xl text-red-600 lg:w-[80px] lg:text-4xl">
         {date}
       </div>

--- a/apps/web/src/app/[locale]/_components/countdown-timer.tsx
+++ b/apps/web/src/app/[locale]/_components/countdown-timer.tsx
@@ -1,6 +1,17 @@
 'use client';
 import { useEffect, useState } from 'react';
 
+const DateCard = ({ date, label }: { date: React.ReactNode; label: string }) => {
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex aspect-square w-[60px] items-center justify-center rounded-xl border bg-white/90 p-2 text-3xl text-red-600 lg:w-[80px] lg:text-4xl">
+        {date}
+      </div>
+      <span className="text-foreground text-sm">{label}</span>
+    </div>
+  );
+};
+
 export const CountdownTimer = () => {
   const releaseDateTimeInMilliSeconds = new Date('2023-12-01T05:00:00.000Z').getTime();
   const [remainingTime, setRemainingTime] = useState(
@@ -22,7 +33,16 @@ export const CountdownTimer = () => {
 
   const { days, hours, minutes, seconds } = calculateTimeComponents(remainingTime);
 
-  return <>{`${days}, ${hours}, ${minutes}, ${seconds}`}</>;
+  if (remainingTime === 0) return null;
+
+  return (
+    <div className="flex gap-4 font-bold tabular-nums">
+      <DateCard date={days} label="Days" />
+      <DateCard date={hours} label="Hours" />
+      <DateCard date={minutes} label="Minutes" />
+      <DateCard date={seconds} label="Seconds" />
+    </div>
+  );
 };
 
 const calculateTimeComponents = (milliseconds: number, isFormatted = false) => {

--- a/apps/web/src/app/[locale]/aot-2023/_components/index.tsx
+++ b/apps/web/src/app/[locale]/aot-2023/_components/index.tsx
@@ -4,6 +4,7 @@ import { About } from './about';
 import { CardGrid } from './card-grid';
 import { Github } from '@repo/ui/icons';
 import { Button } from '@repo/ui/components/button';
+import { CountdownTimer } from '../../_components/countdown-timer';
 
 export async function AotLandingPage() {
   const featureFlags = await getAllFlags();
@@ -20,6 +21,7 @@ export async function AotLandingPage() {
             The first type challenge will unlock at{' '}
             <span className="text-primary">midnight(est)</span> on December 1st
           </p>
+          <CountdownTimer />
           <div className="flex w-full flex-col items-center justify-center gap-2 md:w-auto md:flex-row md:gap-5">
             <a
               target="_blank"


### PR DESCRIPTION
Adds countdown until aot-2023 starts. It will disappear when reaches 0.

## Description
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):

Desktop:
<img width="986" alt="Screenshot 2023-11-29 at 21 00 42" src="https://github.com/typehero/typehero/assets/131662061/5bfdc7b9-812f-4b03-a69d-dc5a5d9e5286">
<img width="983" alt="Screenshot 2023-11-29 at 21 00 36" src="https://github.com/typehero/typehero/assets/131662061/b6489ed2-207c-4554-af96-a8b9badcab48">
Mobile:
<img width="196" alt="Screenshot 2023-11-29 at 21 12 50" src="https://github.com/typehero/typehero/assets/131662061/55e62407-c6bb-474e-8564-3aefeeb615f4">
<img width="202" alt="Screenshot 2023-11-29 at 21 12 56" src="https://github.com/typehero/typehero/assets/131662061/5b6af98c-e677-49d9-abb1-02fac7a00c24">

