### PR TITLE
[Fix] upade loading skeletons on profile pages to match page content

### DIFF
--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/profile-skeleton.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/profile-skeleton.tsx
@@ -1,40 +1,30 @@
 import { Skeleton } from '@repo/ui/components/skeleton';
 
-export function ProfileSkeleton() {
+export function PageContentSkeleton() {
   return (
-    <div className="container flex h-full flex-col gap-8 py-8 md:flex-row">
-      <div className="flex flex-col gap-4 md:flex-row">
-        <div className="flex flex-col items-center gap-4 md:items-start">
-          <Skeleton className="h-32 w-32 rounded-3xl bg-cover md:h-64 md:w-64" />
-          <Skeleton className="mt-4 h-10 w-60 rounded-lg bg-zinc-300 dark:bg-zinc-700 dark:text-white" />
-          <div className="mt-4 flex gap-4 md:w-full md:flex-col">
-            {Array.from({ length: 3 }, (_, idx) => (
-              <TabsTriggerSkeleton key={idx} />
-            ))}
-          </div>
-        </div>
+    <div className="relative flex w-full shrink grow flex-col gap-8">
+      <div className=" flex h-1/2 shrink grow flex-col items-center justify-center space-y-4 rounded-3xl border border-zinc-700 py-10 md:h-2/5 md:w-4/5">
+        <Skeleton className="max-w-80 h-4 w-5/6 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-60 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
       </div>
-      <div className="relative flex shrink grow flex-col gap-8 md:w-2/3">
-        <div className=" flex h-1/2 shrink grow flex-col items-center justify-center space-y-4 rounded-3xl border border-zinc-700 py-10 md:h-2/5 md:w-4/5">
-          <Skeleton className="max-w-80 h-4 w-5/6 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-          <Skeleton className="h-4 w-60 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-          <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-        </div>
-        <div className="relative flex shrink grow flex-col items-center justify-center space-y-4 rounded-3xl border border-zinc-700 py-20 md:h-3/5">
-          <Skeleton className="max-w-80 h-4 w-5/6 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-          <Skeleton className="h-4 w-60 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-          <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
-        </div>
+      <div className="relative flex shrink grow flex-col items-center justify-center space-y-4 rounded-3xl border border-zinc-700 py-20 md:h-3/5">
+        <Skeleton className="max-w-80 h-4 w-5/6 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-60 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
       </div>
     </div>
   );
 }
 
-export function TabsTriggerSkeleton() {
+export function TableSkeleton() {
   return (
-    <div className="flex h-6 flex-row items-center gap-2 rounded-xl  border border-zinc-700 px-2 py-4 md:w-64">
-      <Skeleton className="h-4 w-4 rounded-md border border-zinc-300 bg-zinc-300 dark:bg-zinc-700" />
-      <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+    <div className="relative flex h-[300px] w-full shrink grow flex-col gap-8 md:h-[600px]">
+      <div className="relative flex shrink grow flex-col items-center justify-center space-y-4 rounded-3xl border border-zinc-700 py-20 md:h-3/5">
+        <Skeleton className="max-w-80 h-4 w-5/6 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-60 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+        <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/(profile)/[username]/bookmarks/loading.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/bookmarks/loading.tsx
@@ -1,0 +1,1 @@
+export { TableSkeleton as default } from '../_components/profile-skeleton';

--- a/apps/web/src/app/[locale]/(profile)/[username]/completed/loading.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/completed/loading.tsx
@@ -1,0 +1,1 @@
+export { TableSkeleton as default } from '../_components/profile-skeleton';

--- a/apps/web/src/app/[locale]/(profile)/[username]/in-progress/loading.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/in-progress/loading.tsx
@@ -1,0 +1,1 @@
+export { TableSkeleton as default } from '../_components/profile-skeleton';

--- a/apps/web/src/app/[locale]/(profile)/[username]/loading.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/loading.tsx
@@ -1,1 +1,1 @@
-export { ProfileSkeleton as default } from './_components/profile-skeleton';
+export { PageContentSkeleton as default } from './_components/profile-skeleton';

--- a/apps/web/src/app/[locale]/(profile)/[username]/shared-solutions/loading.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/shared-solutions/loading.tsx
@@ -1,0 +1,1 @@
+export { TableSkeleton as default } from '../_components/profile-skeleton';

--- a/apps/web/src/app/[locale]/settings/_components/settings-skeleton.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/settings-skeleton.tsx
@@ -27,7 +27,7 @@ export function TabsTriggerSkeleton() {
   return (
     <div className="flex h-6 flex-row items-center gap-2 rounded-xl  border border-zinc-700 px-2 py-4 md:w-64">
       <Skeleton className="h-4 w-4 rounded-md border border-zinc-300 bg-zinc-300 dark:bg-zinc-700" />
-      <Skeleton className="h-4 w-20 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white" />
+      <Skeleton className="hidden h-4 w-16 rounded-2xl bg-zinc-300 text-neutral-900 dark:bg-zinc-700 dark:text-white md:block" />
     </div>
   );
 }


### PR DESCRIPTION


## Description
Fixes loading skeleton not matching content of the page

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Triggering suspense boundary in react devtools

## Screenshots/Video (if applicable):
| Before  |After   | 
|--------|-------|
| <img width="232" alt="Screenshot 2023-11-30 at 19 02 31" src="https://github.com/typehero/typehero/assets/131662061/a7bde632-e793-46ff-a188-0ae0be96af01">  | <img width="231" alt="Screenshot 2023-11-30 at 19 04 29" src="https://github.com/typehero/typehero/assets/131662061/1ba8980c-4364-4eeb-88b7-cfdfd4cbccb7"> |
|  <img width="199" alt="Screenshot 2023-11-30 at 18 44 32" src="https://github.com/typehero/typehero/assets/131662061/9041ac44-b5dd-4068-b3e5-5c34b19b1d90"> |  <img width="243" alt="Screenshot 2023-11-30 at 18 50 34" src="https://github.com/typehero/typehero/assets/131662061/41ccc4ed-465b-4a95-b131-2961abee32c1"> |   
| <img width="213" alt="Screenshot 2023-11-30 at 19 55 46" src="https://github.com/typehero/typehero/assets/131662061/e1e25e9a-d97f-46ab-b5fc-ce42bd47153d"> | <img width="211" alt="Screenshot 2023-11-30 at 19 56 08" src="https://github.com/typehero/typehero/assets/131662061/1f486348-afc3-4d9d-8470-4b5b2098d178"> |






