### PR TITLE
fix: Fix typos in literal-types challenge

### DIFF
--- a/challenges/literal-types/user.ts
+++ b/challenges/literal-types/user.ts
@@ -7,6 +7,5 @@ type LiteralFunction = unknown;
 const literalString = undefined;
 const literalTrue = undefined;
 const literalNumber = Math.random() > 0.5 ? undefined : undefined;
-const almostPi = undefined;
 const literalObject = {};
 const literalFunction = () => {};


### PR DESCRIPTION
Fix some typo in the `literal-types` challenge.

## Description

When doing the challenge I have seen some improvements.

- The first we can see in the description of the challenge:

![image](https://github.com/typehero/typehero/assets/17161484/2b5778e7-f8dd-45a2-b09c-1d223c836f93)

- The other fix is that there is no `almostPi` variable in the user panel.


## Related Issue

I don't have created an issue for this fixes. But if I should do, tell me ;)

Thanks for the site <3
