### PR TITLE
style(markdown): add margin bottom to ul and ol tag in markdown

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -51,10 +51,10 @@ export function Markdown({ children, className }: { children: string; className?
           <a className={clsx(className, 'text-blue-500')} {...props} />
         ),
         ul: ({ className, ...props }) => (
-          <ul className={clsx(className, 'list-disc ps-10')} {...props} />
+          <ul className={clsx(className, 'mb-4 list-disc ps-10')} {...props} />
         ),
         ol: ({ className, ...props }) => (
-          <ol className={clsx(className, 'list-decimal ps-10')} {...props} />
+          <ol className={clsx(className, 'mb-4 list-decimal ps-10')} {...props} />
         ),
         h1: ({ className, ...props }) => (
           <h1 className={clsx(className, 'mb-2 pb-2 text-3xl font-bold')} {...props} />


### PR DESCRIPTION
Closes #1223

# Screenshot

<img width="490" alt="Screenshot 2023-12-01 at 8 28 25 PM" src="https://github.com/typehero/typehero/assets/86520455/cd275f5c-a66b-4ecd-9187-cb2817f5080f">
