### PR TITLE
feat:  public api route for getting userstats 

### DIFF
--- a/apps/web/src/app/api/userStats/route.ts
+++ b/apps/web/src/app/api/userStats/route.ts
@@ -1,0 +1,23 @@
+import { prisma } from '@repo/db';
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSolvedChallenges } from '~/app/[locale]/(profile)/[username]/_components/dashboard/_actions';
+
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams;
+  const username = searchParams.get('username');
+  if (!username) {
+    return NextResponse.json({ message: 'username query not found' });
+  }
+  const user = await prisma.user.findFirst({
+    where: {
+      name: {
+        equals: username,
+      },
+    },
+  });
+  if (!user) {
+    return NextResponse.json({ message: 'username not found' });
+  }
+  const stats = await getSolvedChallenges(username);
+  return NextResponse.json(stats);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a basic next get route, with folder named ad userStats, it uses an username query, does prisma call to check if username exists then adds uses the getSolvedChallenges logic to return desired data
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/typehero/typehero/issues/1232
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
