### PR TITLE
fix: TypeHero's profile URL

### DIFF
--- a/packages/db/seed/prod.ts
+++ b/packages/db/seed/prod.ts
@@ -27,7 +27,7 @@ try {
       name: 'TypeHero',
       userLinks: {
         create: {
-          url: 'https://typhero.dev',
+          url: 'https://typehero.dev',
         },
       },
     },


### PR DESCRIPTION
## Description
Fixes a typo in the URL of TypeHero's profile, it was `typhero.dev` and this fixes it to be `typehero.dev`. This is the only place that string appears in the codebase so I'm hoping this fixes it?

## Related Issue
Closes #1246.
