### PR TITLE
disable transition on theme change

### DIFF
--- a/apps/web/src/app/[locale]/providers.tsx
+++ b/apps/web/src/app/[locale]/providers.tsx
@@ -20,7 +20,7 @@ export function Providers({ children }: Props) {
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-right" />
       <SessionProvider>
-        <ThemeProvider attribute="class">
+        <ThemeProvider attribute="class" disableTransitionOnChange>
           <FeatureFlagProvider>
             <TooltipProvider>{children}</TooltipProvider>
           </FeatureFlagProvider>


### PR DESCRIPTION
### What happened?


On theme change, some of the components have a visible blinking effect. 

**Examples:**  

![Screencast from 03-12-23 03_53_52 PM IST](https://github.com/typehero/typehero/assets/62498540/03bcbfcd-6192-42f8-8d1a-3c1b10474f5e)

![Screencast from 03-12-23 03_54_18 PM IST](https://github.com/typehero/typehero/assets/62498540/ca8accd5-05b3-4f1d-8afa-986942d165ea)

![Screencast from 03-12-23 04_18_30 PM IST](https://github.com/typehero/typehero/assets/62498540/0f2ca386-0691-4532-b786-d6e439d705ff)


### Effected Components
This will effect all of the components that have either `transtion-property : color, background-color` or `transition-property: all`  and  a `transtion-duration`. 


### Solution: 

This can be solved by setting the  `disableTransitionOnChange`  prop to `true` in `next-themes` provider.

