### PR TITLE
fix: disable submit buttons when submitting

### DIFF
--- a/apps/admin/src/app/dashboard/tracks/[trackId]/_components/update-track-form.tsx
+++ b/apps/admin/src/app/dashboard/tracks/[trackId]/_components/update-track-form.tsx
@@ -232,7 +232,9 @@ export function UpdateTrackForm({ challenges, track }: Props) {
               <Link href="/?tab=tracks">
                 <Button variant="ghost">Cancel</Button>
               </Link>
-              <Button type="submit">Save</Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                Save
+              </Button>
             </DialogFooter>
           </form>
         </Form>

--- a/apps/admin/src/app/dashboard/tracks/_components/add-track-form.tsx
+++ b/apps/admin/src/app/dashboard/tracks/_components/add-track-form.tsx
@@ -123,7 +123,9 @@ export function AddTrackForm({ toggle }: Props) {
           )}
         />
         <DialogFooter className="py-3">
-          <Button type="submit">Save</Button>
+          <Button type="submit" disabled={form.formState.isSubmitting}>
+            Save
+          </Button>
         </DialogFooter>
       </form>
     </Form>

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/edit-solution.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/edit-solution.tsx
@@ -99,7 +99,11 @@ export function EditSolution({ solution, setIsEditing }: Props) {
           >
             Cancel
           </Button>
-          <Button className="h-8 rounded-lg px-3 py-2" type="submit">
+          <Button
+            className="h-8 rounded-lg px-3 py-2"
+            type="submit"
+            disabled={form.formState.isSubmitting}
+          >
             Update
           </Button>
         </div>

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-editor.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-editor.tsx
@@ -123,7 +123,11 @@ export function SolutionEditor({ dismiss, challengeId, code }: Props) {
           >
             Cancel
           </Button>
-          <Button className="my-1 h-8 rounded-lg px-3 py-2" type="submit">
+          <Button
+            className="my-1 h-8 rounded-lg px-3 py-2"
+            type="submit"
+            disabled={form.formState.isSubmitting}
+          >
             Post
           </Button>
         </div>

--- a/apps/web/src/app/[locale]/challenge/_components/settings/settings-form.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/settings/settings-form.tsx
@@ -146,7 +146,9 @@ export function SettingsForm() {
 
         <DialogFooter className="mt-3">
           <DialogPrimitive.Close asChild>
-            <Button type="submit">Save</Button>
+            <Button type="submit" disabled={form.formState.isSubmitting}>
+              Save
+            </Button>
           </DialogPrimitive.Close>
         </DialogFooter>
       </form>

--- a/apps/web/src/app/[locale]/claim/claim-form.tsx
+++ b/apps/web/src/app/[locale]/claim/claim-form.tsx
@@ -53,7 +53,7 @@ export function ClaimForm() {
           )}
         />
 
-        <Button className="h-10 rounded-xl" type="submit">
+        <Button className="h-10 rounded-xl" type="submit" disabled={form.formState.isSubmitting}>
           Submit
         </Button>
       </form>

--- a/apps/web/src/app/[locale]/settings/_components/edit-profile-tab.tsx
+++ b/apps/web/src/app/[locale]/settings/_components/edit-profile-tab.tsx
@@ -113,7 +113,9 @@ function ProfileForm({ user }: Props) {
           })}
         </div>
 
-        <Button type="submit">Update profile</Button>
+        <Button type="submit" disabled={form.formState.isSubmitting}>
+          Update profile
+        </Button>
       </form>
     </Form>
   );

--- a/apps/web/src/app/[locale]/wizard/_components/NextBack.tsx
+++ b/apps/web/src/app/[locale]/wizard/_components/NextBack.tsx
@@ -6,9 +6,10 @@ interface Props {
   onChange: (index: number) => void;
   onNext: () => void;
   onSubmit: () => Promise<void>;
+  isSubmitting: boolean;
 }
 
-export function NextBack({ current, onChange, onNext, onSubmit }: Props) {
+export function NextBack({ current, onChange, onNext, onSubmit, isSubmitting }: Props) {
   return (
     <div className={`flex justify-center gap-3 ${current === STEPS.Summary && ''}`}>
       {current > STEPS.ChallengeCard && (
@@ -16,6 +17,7 @@ export function NextBack({ current, onChange, onNext, onSubmit }: Props) {
           className="rounded-full bg-neutral-200 duration-300 active:scale-95 dark:bg-neutral-800 dark:hover:bg-neutral-700"
           onClick={() => onChange(current - 1)}
           variant="ghost"
+          disabled={isSubmitting}
         >
           Back
         </Button>
@@ -24,6 +26,7 @@ export function NextBack({ current, onChange, onNext, onSubmit }: Props) {
         <Button
           className="w-[79px] rounded-full transition-all duration-300 ease-out hover:px-16 active:scale-95"
           onClick={onSubmit}
+          disabled={isSubmitting}
         >
           Submit
         </Button>
@@ -31,6 +34,7 @@ export function NextBack({ current, onChange, onNext, onSubmit }: Props) {
         <Button
           className="w-[79px] rounded-full transition-all duration-300 ease-out active:scale-95"
           onClick={onNext}
+          disabled={isSubmitting}
         >
           Next
         </Button>

--- a/apps/web/src/app/[locale]/wizard/_components/index.tsx
+++ b/apps/web/src/app/[locale]/wizard/_components/index.tsx
@@ -174,6 +174,7 @@ export function Wizard() {
         onChange={(idx) => setStep(idx)}
         onNext={handleNextClick}
         onSubmit={form.handleSubmit(onSubmit)}
+        isSubmitting={form.formState.isSubmitting}
       />
     </div>
   );


### PR DESCRIPTION
Visual feedback on clicking buttons is important. Buttons that don't react to a click tend to confuse users and get double clicked. Poof poof one-two combo

## Description
Just using `form.formState.isSubmitting` to disable the submit button in all react-hook-form forms that I could find.

## How Has This Been Tested?
Clickety click on a submit button. Typescript seems to be happy.

## Screenshots/Video (if applicable):
![EQv5BXLmsD](https://github.com/typehero/typehero/assets/5869818/c5a9ed40-aa2a-4d6a-a82d-c7c5f9fec1cf)
