### PR TITLE
fix: typos in challenges (#1257)

### DIFF
--- a/challenges/generic-type-arguments/prompt.md
+++ b/challenges/generic-type-arguments/prompt.md
@@ -66,7 +66,7 @@ type GroceryItem<Name, Price, InStock> = {
 };
 ```
 
-Now you can change pass arguments to this type:
+Now you can pass arguments to this type:
 
 ```ts
 type AvocadoToast = GroceryItem<'Avocado Toast', 12.99, true>;

--- a/challenges/mapped-object-types/prompt.md
+++ b/challenges/mapped-object-types/prompt.md
@@ -43,7 +43,7 @@ Let's talk about what this syntax does, piece by piece:
 - `;` it might at first seem strange, but if you take a step back, this is just a `property: value` line in an object type, so we end it with a semicolon like we normally would with types in TypeScript.
 - `};` ends the type declaration.
 
-But, all this _stuff_ but we end up with a type that's literally identical to what we started with. In the above code, `Example` and `MoviesByGenre` are literally the same type to TypeScript because TypeScript is a structural type system. They have all the same properties and values, so to TypeScript they are basically aliases at this point (aliases with extra steps, granted!).
+But, all this _stuff_, and we end up with a type that's literally identical to what we started with. In the above code, `Example` and `MoviesByGenre` are literally the same type to TypeScript because TypeScript is a structural type system. They have all the same properties and values, so to TypeScript they are basically aliases at this point (aliases with extra steps, granted!).
 
 ### Resetting all values
 


### PR DESCRIPTION
Fixes Typos in Generic Type Arguments and Mapped Object Types

<!--- Provide a general summary of your changes in the Title above -->

## Description
Noticed couple minor typos in Challenges [Generic Type Arguments](https://typehero.dev/challenge/generic-type-arguments) and [Mapped Object Types](https://typehero.dev/challenge/mapped-object-types)

Generic Type Arguments
> Now you can change pass arguments to this type:
**Expected**: Now you can pass arguments to this type:

Mapped Object Types
> But, all this stuff but we end up with a type that's literally identical to what we started with.
**Expected**: But, all this stuff, and we end up with a type that's literally identical to what we started with.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1257