### PR TITLE
feat: #1267 Top Loader Progressbar between page transitions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
     "next": "14.0.1",
     "next-international": "1.1.4",
     "next-themes": "^0.2.1",
+    "nextjs-toploader": "^1.6.4",
     "react": "^18.2.0",
     "react-day-picker": "^8.8.0",
     "react-dnd": "^16.0.1",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import NextTopLoader from 'nextjs-toploader';
 import { Toaster } from '@repo/ui/components/toaster';
 import { Analytics } from '@vercel/analytics/react';
 import { Inter } from 'next/font/google';
@@ -66,6 +67,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="manifest" href="/site.webmanifest" />
       </head>
       <body className={`${inter.className} flex flex-col`}>
+        <NextTopLoader
+          color="#2299DD"
+          initialPosition={0.08}
+          crawlSpeed={200}
+          height={5}
+          crawl={true}
+          showSpinner={false}
+          easing="ease"
+          speed={200}
+          shadow="0 0 10px #2299DD,0 0 5px #2299DD"
+          template='
+              <div class="bar sparkling-snow" role="bar"><div class="peg"></div></div>
+              <div class="spinner" role="spinner"><div class="custom-spinner-icon"></div></div>'
+          zIndex={1600}
+          showAtBottom={false}
+        />
         <Providers>
           <Navigation />
           {children}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -754,3 +754,30 @@ a {
 body.mobile-nav-active {
   overflow: hidden;
 }
+
+@keyframes sparkle {
+  0% {
+    background-color: #2299dd;
+    opacity: 1;
+  }
+  50% {
+    background-color: #ffffff;
+    opacity: 0.5;
+  }
+  100% {
+    background-color: #2299dd;
+    opacity: 1;
+  }
+}
+
+.sparkling-snow {
+  animation: sparkle 1s linear infinite;
+}
+
+.custom-spinner-icon {
+  border: 2px solid #2299dd;
+  border-top: 2px solid #ffffff;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
## Description
- Adding a top loading bar using the nextjs-toploader library, with custom CSS styling. 
- This feature will help improve user experience in the TypeHero WebApp by providing a visual page loading progress, during page transitions. 
- It addresses the issue where users may be uncertain if their click was registered due to a delay in loading new pages. 


## Related Issue
Closes #1267 


## Motivation and Context
Since i started using TypeHero, sometimes initially when switching between pages, it takes more than 1 or 2 sometime even 3 seconds to load new page, (mostly during dynamic pages), so in this case it feels like nothing is happening on page for few seconds, so user can be in doubt if the click actually worked or not. 

So, providing a Progress Bar on Top of the page like we see in many popular webapps, would show  users that click is registered and page is being loaded.


## How Has This Been Tested?
The implementation was tested across different browsers (except Safari as i don't use Mac) to ensure compatibility. 



## Screenshots/Video (if applicable):
![image](https://github.com/typehero/typehero/assets/46242040/c6beb6b9-1d84-492f-8c99-a92b45386047)

