### PR TITLE
fix: on hover badges tooltip fix

### DIFF
--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/badges.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/badges.tsx
@@ -27,7 +27,9 @@ const Badge = ({ slug, name }: BadgeInfo) => {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Icon className="h-12 w-12" />
+        <span>
+          <Icon className="h-12 w-12" />
+        </span>
       </TooltipTrigger>
       <TooltipContent side="bottom">
         <span>{name}</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
looking at other tooltip every icon is wrapped with button element, 
badges tooltip icon didn't had any wrapper, thus adding a span wrapper does the work,
if wanted i can do button wrapper instead to span but it will add cursor pointer to it, let me know if we need it

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/typehero/typehero/issues/1270
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
[Screencast from 06-12-23 03:57:43 PM IST.webm](https://github.com/typehero/typehero/assets/114667178/90164f04-a3d3-440a-a922-390cb228b858)
