### PR TITLE
fix(monaco): handle diagnostic message chains

### DIFF
--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -484,7 +484,7 @@ async function typeCheck(monaco: typeof monacoType) {
         endLineNumber: end.lineNumber,
         startColumn: start.column,
         endColumn: end.column,
-        message: d.messageText as string,
+        message: ts.flattenDiagnosticMessageText(d.messageText, '\n'),
       } satisfies monacoType.editor.IMarkerData;
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the handling of diagnostic message chains in the Monaco split editor. Instead of
assuming that `messageText` is a string, we now call out to TypeScript to flatten the message for
us, which fixes the occasional `[object Object]` error messages.

## Related Issue

Closes #1272.

## Motivation and Context

This PR ensures that error messages are displayed properly in Monaco in order to provide adequate
information about what's wrong to the user.

## How Has This Been Tested?

I've confirmed that the `readonly` error is no longer an issue.

## Screenshots/Video (if applicable):

![image](https://github.com/typehero/typehero/assets/38114607/3e38dd90-b5f5-455e-9027-6c5365dfe76a)