### PR TITLE
Updated newsletter description to stay the same on both landing page …

### DIFF
--- a/apps/web/src/app/[locale]/(email)/newsletter/_components/index.tsx
+++ b/apps/web/src/app/[locale]/(email)/newsletter/_components/index.tsx
@@ -23,8 +23,9 @@ export function Newsletter({ params: { locale } }: { params: { locale: string } 
           </h1>
           <p className="leading-8 text-black/50 dark:text-white/50">
             <Balancer>
-              By subscribing to the TypeHero newsletter, you will be at the forefront of updates,
-              insights, and exclusive content.
+              Dive into the world of TypeScript excellence! Join us on the journey to becoming a
+              better TypeScript developer. By subscribing to the TypeHero newsletter, you will be at
+              the forefront of updates, insights, and exclusive content.
             </Balancer>
           </p>
           <NewsletterForm />

--- a/apps/web/src/app/[locale]/(email)/newsletter/_components/newsletter-form.tsx
+++ b/apps/web/src/app/[locale]/(email)/newsletter/_components/newsletter-form.tsx
@@ -147,10 +147,15 @@ export function NewsletterForm() {
       </Form>
       <div className="mt-3">
         {mutation.status === 'success' && <AlertSuccess />}
-        {mutation.status === 'error' && mutation.error?.message === 'Member Exists' ? (
-          <AlertSuccess />
-        ) : (
-          <AlertDestructive text={'Something went wrong, please try again.'} />
+        {mutation.status === 'error' && (
+          <AlertDestructive
+            text={
+              // @ts-ignore
+              mutation.error?.message === 'Member Exists'
+                ? 'You have already subscribed using this email!'
+                : 'Something went wrong, please try again.'
+            }
+          />
         )}
       </div>
     </div>

--- a/apps/web/src/app/[locale]/(email)/newsletter/_components/newsletter-form.tsx
+++ b/apps/web/src/app/[locale]/(email)/newsletter/_components/newsletter-form.tsx
@@ -147,15 +147,10 @@ export function NewsletterForm() {
       </Form>
       <div className="mt-3">
         {mutation.status === 'success' && <AlertSuccess />}
-        {mutation.status === 'error' && (
-          <AlertDestructive
-            text={
-              // @ts-ignore
-              mutation.error?.message === 'Member Exists'
-                ? 'You have already subscribed using this email!'
-                : 'Something went wrong, please try again.'
-            }
-          />
+        {mutation.status === 'error' && mutation.error?.message === 'Member Exists' ? (
+          <AlertSuccess />
+        ) : (
+          <AlertDestructive text={'Something went wrong, please try again.'} />
         )}
       </div>
     </div>

--- a/apps/web/src/app/[locale]/_components/newsletter-banner.tsx
+++ b/apps/web/src/app/[locale]/_components/newsletter-banner.tsx
@@ -16,7 +16,8 @@ export function NewsletterBanner() {
           <p className="leading-8 text-black/50 dark:text-white/50">
             <Balancer>
               Dive into the world of TypeScript excellence! Join us on the journey to becoming a
-              better TypeScript developer.
+              better TypeScript developer. By subscribing to the TypeHero newsletter, you will be at
+              the forefront of updates, insights, and exclusive content.
             </Balancer>
           </p>
         </div>


### PR DESCRIPTION
Follow-up from https://github.com/typehero/typehero/pull/1275.

1. Updated description to be the same in landing page and /newsletter.
2. Only show success message when subscribing as suggested by @aadamw. Let me know if this looks good!