### PR TITLE
issue-1280 extend out issue on bio with really long character string. 

### DIFF
--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
@@ -20,12 +20,12 @@ export async function OverviewTab({ user }: Props) {
         {/* //Todo: Filling with void for now, may put contributions / something else */}
         <div className="max-w-sm flex-grow" />
       </div>
-      <Card className="flex-grow">
+      <Card className="flex-grow w-full md:max-w-[800px]">
         <CardHeader>
           <CardTitle>Bio</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="w-full text-sm">
+          <div className="w-full text-sm break-words">
             {hasBio ? (
               <Markdown>{user.bio}</Markdown>
             ) : (

--- a/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
+++ b/apps/web/src/app/[locale]/(profile)/[username]/_components/dashboard/overview-tab.tsx
@@ -20,12 +20,12 @@ export async function OverviewTab({ user }: Props) {
         {/* //Todo: Filling with void for now, may put contributions / something else */}
         <div className="max-w-sm flex-grow" />
       </div>
-      <Card className="flex-grow w-full md:max-w-[800px]">
+      <Card className="w-full flex-grow md:max-w-[800px]">
         <CardHeader>
           <CardTitle>Bio</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="w-full text-sm break-words">
+          <div className="w-full break-words text-sm">
             {hasBio ? (
               <Markdown>{user.bio}</Markdown>
             ) : (


### PR DESCRIPTION
## Description
Bio extends out when typing in a really long character string. Hence, max width and break words is set to prevent this type of case from happening. If there's any disagreement with the max-width just let me know and I can change it! 


## Related Issue
https://github.com/typehero/typehero/issues/1280 


## Motivation and Context
See description


## How Has This Been Tested?
Tested locally on dev on both mobile view (Iphone 14) and browser with strings that have 256 characters and also tested with other long strings. 

## Screenshots/Video (if applicable):
<img width="883" alt="Screenshot 2023-12-09 at 4 45 24 PM" src="https://github.com/typehero/typehero/assets/24363724/887998b3-3d73-48e8-9022-d6c3786ac8c1">

<img width="400" alt="Screenshot 2023-12-09 at 4 44 43 PM" src="https://github.com/typehero/typehero/assets/24363724/5e722386-2b24-4823-af52-28b809584b45">
