### PR TITLE
bug: background blur color fix on light mode

### DIFF
--- a/apps/web/src/app/[locale]/explore/_components/explore-section.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-section.tsx
@@ -48,8 +48,8 @@ const TITLES_BY_TAG = {
 export const COLORS_BY_TAGS = {
   POPULAR: 'dark:bg-pink-300 bg-pink-600/50',
   NEWEST: 'dark:bg-orange-300 bg-orange-500/50',
-  BEGINNER: 'dark:bg-blue-300 bg-blue-600/50',
-  EASY: 'dark:bg-green-300 bg-green-500/50',
+  BEGINNER: 'dark:bg-sky-300 bg-sky-600/50',
+  EASY: 'dark:bg-green-300 bg-green-600/50',
   MEDIUM: 'dark:bg-yellow-300 bg-yellow-600/50',
   HARD: 'dark:bg-red-300 bg-red-600/50',
   EXTREME: 'dark:bg-purple-300 bg-purple-600/50',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix background blur color on light mode

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
Before:
![image](https://github.com/typehero/typehero/assets/69889382/8d9fda6e-7875-468e-b479-0dd4e9f3131e)

After:
![image](https://github.com/typehero/typehero/assets/69889382/eb735555-aa70-45a2-8b93-a860438bb3c5)
