### PR TITLE
issue 1310 : The <a> tag inside the <p> tag extends wider than the width of the <p> tag. 

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -48,7 +48,7 @@ export function Markdown({ children, className }: { children: string; className?
       className={className}
       components={{
         a: ({ className, ...props }) => (
-          <a className={clsx(className, 'text-blue-500')} {...props} />
+          <a className={clsx(className, 'whitespace-nowrap text-blue-500')} {...props} />
         ),
         ul: ({ className, ...props }) => (
           <ul className={clsx(className, 'mb-4 list-disc ps-10')} {...props} />

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -65,7 +65,9 @@ export function Markdown({ children, className }: { children: string; className?
         h3: ({ className, ...props }) => (
           <h3 className={clsx(className, 'mb-2 pb-2 text-xl font-bold')} {...props} />
         ),
-        p: ({ className, ...props }) => <p className={clsx(className, 'mb-4')} {...props} />,
+        p: ({ className, ...props }) => (
+          <p className={clsx(className, 'mb-4 overflow-hidden text-ellipsis')} {...props} />
+        ),
         code({ inline, className, children, style: _, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
           return !inline && match ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I add text-overflow: ellipsis to p in markdown so width of the a tag does not exceed the width of the p tag.
I add white-space:nowrap to a in markdown to prevent automatic line breaks in <a> tags at firefox browser

## Related Issue
#1310 

## Screenshots/Video (if applicable):
![Screenshot 2023-12-11 at 2 29 12 PM](https://github.com/typehero/typehero/assets/62943813/2fb48ad9-ecc6-44da-a605-887542e34e00)
