### PR TITLE
Fix: Improve a11y on homepage (Added link names & fixed contrast)

### DIFF
--- a/apps/web/src/app/[locale]/_components/community/community.tsx
+++ b/apps/web/src/app/[locale]/_components/community/community.tsx
@@ -91,7 +91,7 @@ export function Community() {
               <h2 className="mt-2 text-center text-4xl font-bold lg:text-left">
                 Built by the community
               </h2>
-              <p className="max-w-[55ch] bg-transparent px-8 text-center leading-8 text-black/50 dark:text-white/50 lg:px-0 lg:text-left">
+              <p className="max-w-[55ch] bg-transparent px-8 text-center leading-8 text-black/60 dark:text-white/50 lg:px-0 lg:text-left">
                 TypeHero is free, open-source, and built by developers just like you. These are some
                 of the contributors who made this possible so far.
               </p>

--- a/apps/web/src/app/[locale]/_components/features.tsx
+++ b/apps/web/src/app/[locale]/_components/features.tsx
@@ -58,7 +58,7 @@ export async function Features() {
             <h1 className="text-4xl font-bold">
               <Balancer>{t('title')}</Balancer>
             </h1>
-            <p className="text-black/50 dark:text-white/50">
+            <p className="text-black/60 dark:text-white/50">
               <Balancer>{t('description')}</Balancer>
             </p>
           </div>

--- a/apps/web/src/app/[locale]/_components/newsletter-banner.tsx
+++ b/apps/web/src/app/[locale]/_components/newsletter-banner.tsx
@@ -13,7 +13,7 @@ export function NewsletterBanner() {
           <h1 className="max-w-[13ch] text-4xl font-bold md:max-w-none">
             <Balancer>Stay Informed</Balancer>
           </h1>
-          <p className="leading-8 text-black/50 dark:text-white/50">
+          <p className="leading-8 text-black/60 dark:text-white/50">
             <Balancer>
               Dive into the world of TypeScript excellence! Join us on the journey to becoming a
               better TypeScript developer. By subscribing to the TypeHero newsletter, you will be at

--- a/apps/web/src/components/footsies.tsx
+++ b/apps/web/src/components/footsies.tsx
@@ -19,6 +19,7 @@ export function Footsies() {
             className="group rounded-lg p-2"
             href="https://github.com/typehero/typehero"
           >
+            <span className="sr-only">TypeHero on Github</span>
             <Github className="h-5 w-5 duration-150 group-hover:scale-110 group-hover:fill-black dark:group-hover:fill-white" />
           </a>
           <a
@@ -27,6 +28,7 @@ export function Footsies() {
             className="group rounded-lg p-2"
             href="https://twitter.com/typeheroapp"
           >
+            <span className="sr-only">TypeHero on Twitter</span>
             <Twitter className="h-5 w-5 duration-150 group-hover:scale-110 group-hover:fill-black dark:group-hover:fill-white" />
           </a>
         </div>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->


<!--- Provide a general summary of your changes in the Title above -->
This PR fixes following a11y issues on the homepage
- Adds discernible name for github & twitter links in the footer using sr-only tailwind utility
- Fixes color contrast by changing text-black/50 to text-black/60 on light mode



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Relates to #242

## Screenshots/Video (if applicable):
It fixes these issues (Multiple contrast issues in light mode on homepage)
![a11y contrast issue typehero](https://github.com/typehero/typehero/assets/17196143/658f8132-96ad-4608-beee-e1fd9b0a7c78)
![a11y link issue typehero](https://github.com/typehero/typehero/assets/17196143/93baa233-9b7e-4101-98cc-14b17aec7b7a)
### Lighthouse a11y score before this fix:
![image](https://github.com/typehero/typehero/assets/17196143/4d0f6796-58d2-4a8f-bf83-0c5824c07a72)
### Lighthouse a11y score after this fix:
![image](https://github.com/typehero/typehero/assets/17196143/824adefe-5d17-4e64-93a7-3312711e23c5)
