### PR TITLE
fix: same challenge being suggested again

### DIFF
--- a/apps/web/src/utils/server/get-similar-challenges.ts
+++ b/apps/web/src/utils/server/get-similar-challenges.ts
@@ -37,7 +37,7 @@ export async function getSimilarChallenges(
       where: {
         difficulty,
         id: {
-          notIn: solvedSolutions.flatMap((solution) => solution.challengeId),
+          notIn: [...solvedSolutions.flatMap((solution) => solution.challengeId), challengeId],
         },
       },
       take: maxChallenges,
@@ -47,7 +47,7 @@ export async function getSimilarChallenges(
       const firstUnsolved = await prisma.challenge.findMany({
         where: {
           id: {
-            notIn: solvedSolutions.flatMap((solution) => solution.challengeId),
+            notIn: [...solvedSolutions.flatMap((solution) => solution.challengeId), challengeId],
           },
         },
         take: maxChallenges,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
notIn was exluding only the solved challenges, adding the challengeId ( challenge user is currently on ) to the array of challengeIds to exluded fixes the issue
## Description
<!--- Describe your changes in detail -->
earlier: only solved challengeId's were exluded
now: along with solved challengeId's , current challengeId is also being excluded
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/typehero/typehero/issues/1316
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
Before:
[Screencast from 12-12-23 08:35:37 PM IST.webm](https://github.com/typehero/typehero/assets/114667178/2a880a20-79f6-466e-8884-d95e2972f772)

After:
[Screencast from 12-12-23 08:36:29 PM IST.webm](https://github.com/typehero/typehero/assets/114667178/549b2c0b-e1ac-45e5-a78f-5215fb5a55d7)
