### PR TITLE
fix: make "view more" button on /explore an actual link instead of button with onClick

### DIFF
--- a/apps/web/src/app/[locale]/explore/_components/view-more-button.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/view-more-button.tsx
@@ -1,8 +1,6 @@
-'use client';
-
 import { Button } from '@repo/ui/components/button';
 import { ChevronRight } from '@repo/ui/icons';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 export const BUTTON_BY_TAGS = {
   POPULAR:
@@ -28,18 +26,16 @@ interface ViewMoreButtonProps {
 }
 
 export function ViewMoreButton({ redirectRoute, tag }: ViewMoreButtonProps) {
-  const router = useRouter();
   return (
-    <Button
-      className={`group items-center whitespace-nowrap rounded-full py-2 pl-4 pr-3 backdrop-blur-sm
+    <Link href={redirectRoute}>
+      <Button
+        className={`group items-center whitespace-nowrap rounded-full py-2 pl-4 pr-3 backdrop-blur-sm
   ${BUTTON_BY_TAGS[tag]}`}
-      onClick={() => {
-        router.push(redirectRoute);
-      }}
-      variant="ghost"
-    >
-      view more
-      <ChevronRight className="ml-2 h-4 w-4 stroke-[3] duration-300 group-hover:translate-x-1" />
-    </Button>
+        variant="ghost"
+      >
+        view more
+        <ChevronRight className="ml-2 h-4 w-4 stroke-[3] duration-300 group-hover:translate-x-1" />
+      </Button>
+    </Link>
   );
 }

--- a/apps/web/src/app/[locale]/explore/_components/view-more-button.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/view-more-button.tsx
@@ -27,15 +27,16 @@ interface ViewMoreButtonProps {
 
 export function ViewMoreButton({ redirectRoute, tag }: ViewMoreButtonProps) {
   return (
-    <Link href={redirectRoute}>
-      <Button
-        className={`group items-center whitespace-nowrap rounded-full py-2 pl-4 pr-3 backdrop-blur-sm
+    <Button
+      asChild
+      className={`group items-center whitespace-nowrap rounded-full py-2 pl-4 pr-3 backdrop-blur-sm
   ${BUTTON_BY_TAGS[tag]}`}
-        variant="ghost"
-      >
+      variant="ghost"
+    >
+      <Link href={redirectRoute}>
         view more
         <ChevronRight className="ml-2 h-4 w-4 stroke-[3] duration-300 group-hover:translate-x-1" />
-      </Button>
-    </Link>
+      </Link>
+    </Button>
   );
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Basically wraps whole `ViewMoreButton` in the Next `<Link/>` and removes onClick handler.

Since it doesn't use `useRouter` anymore - we can remove `"use client"` directive too

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1329

## Motivation and Context
It's a bit painful to manually duplicate a page when you want to go for specific difficulty section. Making a link _an actual_ link resolves the issue
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually tested

## Screenshots/Video (if applicable):
before/after video:
[github hates .mkv - here is youtube link](https://www.youtube.com/watch?v=tFTeVAg71mo)