### PR TITLE
fix(search): don't perform empty queries

### DIFF
--- a/apps/web/src/components/search/search-provider.tsx
+++ b/apps/web/src/components/search/search-provider.tsx
@@ -16,7 +16,27 @@ const INDEX_NAME = 'typehero';
 
 export function SearchProvider({ children }: { children: React.ReactNode }) {
   return (
-    <InstantSearchNext searchClient={searchClient} indexName={INDEX_NAME}>
+    <InstantSearchNext
+      searchClient={{
+        ...searchClient,
+        search(requests) {
+          const isEmptyQuery = requests.every(({ params }) => !params?.query);
+          if (isEmptyQuery) {
+            return Promise.resolve({
+              results: requests.map(
+                () =>
+                  ({
+                    hits: [],
+                  }) as never,
+              ),
+            });
+          }
+
+          return searchClient.search(requests);
+        },
+      }}
+      indexName={INDEX_NAME}
+    >
       {children}
     </InstantSearchNext>
   );


### PR DESCRIPTION
## Description

This PR fixes the infamous Instantsearch query on mount issue by detecting empty searches and
resolving with an empty response. Previously, every time someone loaded the landing page (or any
page that has the search box), a query was performed, which racked up a lot of requests. Not ideal,
considering there's a quota.

## Related Issue

N/A

## Motivation and Context

Basically the description.

## How Has This Been Tested?

I've confirmed locally that the newly added code correctly detects empty queries and handles them
locally as opposed to hitting Algolia.

## Screenshots/Video (if applicable):

N/A
