### PR TITLE
feat: add page querystring to url at solution

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
@@ -16,8 +16,8 @@ import { Pagination } from '../../../_components/pagination';
 import { useQuery } from '@tanstack/react-query';
 import { SolutionsSkeleton } from './solution-skeleton';
 import { SortSelect } from '../../../_components/sort-select';
-import useQueryParamState from './useQueryParamState';
-import useGetQueryString from './useGetQueryString';
+import { useGetQueryString } from './useGetQueryString';
+import { useQueryParamState } from './useQueryParamState';
 
 interface Props {
   slug: string;
@@ -151,7 +151,6 @@ function SolutionRow({
     <Link
       href={`/challenge/${slug}/solutions/${solution.id}?${queryString}`}
       className="flex cursor-pointer flex-col gap-2 p-4 duration-300 hover:bg-neutral-100 dark:hover:bg-zinc-700/50"
-      // href={}
     >
       <h3 className="truncate font-bold">{solution.title}</h3>
       <div className="flex items-center gap-2">

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
@@ -146,11 +146,10 @@ function SolutionRow({
   solution: NonNullable<PaginatedSolution['sharedSolution']>[number];
 }) {
   const { slug } = useParams();
-  const queryString  =useGetQueryString()
+  const queryString = useGetQueryString();
   return (
-    <Link 
-    href ={`/challenge/${slug}/solutions/${solution.id}?${queryString}` }
-
+    <Link
+      href={`/challenge/${slug}/solutions/${solution.id}?${queryString}`}
       className="flex cursor-pointer flex-col gap-2 p-4 duration-300 hover:bg-neutral-100 dark:hover:bg-zinc-700/50"
       // href={}
     >

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
@@ -17,6 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { SolutionsSkeleton } from './solution-skeleton';
 import { SortSelect } from '../../../_components/sort-select';
 import useQueryParamState from './useQueryParamState';
+import useGetQueryString from './useGetQueryString';
 
 interface Props {
   slug: string;
@@ -145,10 +146,13 @@ function SolutionRow({
   solution: NonNullable<PaginatedSolution['sharedSolution']>[number];
 }) {
   const { slug } = useParams();
+  const queryString  =useGetQueryString()
   return (
-    <Link
+    <Link 
+    href ={`/challenge/${slug}/solutions/${solution.id}?${queryString}` }
+
       className="flex cursor-pointer flex-col gap-2 p-4 duration-300 hover:bg-neutral-100 dark:hover:bg-zinc-700/50"
-      href={`/challenge/${slug}/solutions/${solution.id}`}
+      // href={}
     >
       <h3 className="truncate font-bold">{solution.title}</h3>
       <div className="flex items-center gap-2">

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/index.tsx
@@ -16,6 +16,7 @@ import { Pagination } from '../../../_components/pagination';
 import { useQuery } from '@tanstack/react-query';
 import { SolutionsSkeleton } from './solution-skeleton';
 import { SortSelect } from '../../../_components/sort-select';
+import useQueryParamState from './useQueryParamState';
 
 interface Props {
   slug: string;
@@ -48,7 +49,7 @@ export function Solutions({ slug }: Props) {
   const [view, setView] = useState<View>('list');
   const commentContainerRef = useRef<HTMLDivElement>(null);
   const [sortKey, setSortKey] = useState<(typeof SORT_KEYS)[number]>(SORT_KEYS[0]);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useQueryParamState<number>('page', 1);
   const queryKey = ['challenge-solutions', slug, page, sortKey.key, sortKey.order];
   const session = useSession();
 

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
@@ -33,7 +33,7 @@ export function SolutionDetails({ solution }: Props) {
   const { data: session } = useSession();
   const showPin = isAdminOrModerator(session);
   const [isEditing, setIsEditing] = useState(false);
-  const queryString = useGetQueryString()
+  const queryString = useGetQueryString();
 
   const handlePinClick = async () => {
     await pinOrUnpinSolution(solution.id, !solution.isPinned, slug as string);

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
@@ -22,7 +22,7 @@ import { SolutionDeleteDialog } from './delete';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 import { EditSolution } from './edit-solution';
-import useGetQueryString from './useGetQueryString';
+import { useGetQueryString } from './useGetQueryString';
 
 interface Props {
   solution: ChallengeSolution;

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
@@ -19,7 +19,7 @@ import { Vote } from '../../../_components/vote';
 import { pinOrUnpinSolution } from './_actions';
 import { isAdminOrModerator, isAuthor } from '~/utils/auth-guards';
 import { SolutionDeleteDialog } from './delete';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { EditSolution } from './edit-solution';
 
@@ -32,6 +32,11 @@ export function SolutionDetails({ solution }: Props) {
   const { data: session } = useSession();
   const showPin = isAdminOrModerator(session);
   const [isEditing, setIsEditing] = useState(false);
+
+  const router = useRouter();
+  const handleClickLeftIcon = () => {
+    router.back();
+  };
 
   const handlePinClick = async () => {
     await pinOrUnpinSolution(solution.id, !solution.isPinned, slug as string);
@@ -53,11 +58,11 @@ export function SolutionDetails({ solution }: Props) {
         <div className="custom-scrollable-element flex-1 overflow-y-auto px-4 pb-16 pt-3">
           <div className="mb-5 flex flex-col gap-3">
             <div className="flex items-center gap-3">
-              <Link href={`/challenge/${slug}/solutions`} className="h-7 w-7">
+              <button onClick={handleClickLeftIcon} className="h-7 w-7">
                 <div className="rounded-full p-1 hover:bg-gray-200 hover:bg-opacity-10">
                   <ArrowLeft className="stroke-gray-500" size={20} />
                 </div>
-              </Link>
+              </button>
               <div className="flex items-center gap-2">
                 <Avatar className="h-7 w-7">
                   <AvatarImage alt="github profile picture" src={solution.user?.image ?? ''} />

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/solution-detail.tsx
@@ -19,9 +19,10 @@ import { Vote } from '../../../_components/vote';
 import { pinOrUnpinSolution } from './_actions';
 import { isAdminOrModerator, isAuthor } from '~/utils/auth-guards';
 import { SolutionDeleteDialog } from './delete';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useState } from 'react';
 import { EditSolution } from './edit-solution';
+import useGetQueryString from './useGetQueryString';
 
 interface Props {
   solution: ChallengeSolution;
@@ -32,11 +33,7 @@ export function SolutionDetails({ solution }: Props) {
   const { data: session } = useSession();
   const showPin = isAdminOrModerator(session);
   const [isEditing, setIsEditing] = useState(false);
-
-  const router = useRouter();
-  const handleClickLeftIcon = () => {
-    router.back();
-  };
+  const queryString = useGetQueryString()
 
   const handlePinClick = async () => {
     await pinOrUnpinSolution(solution.id, !solution.isPinned, slug as string);
@@ -51,18 +48,17 @@ export function SolutionDetails({ solution }: Props) {
       });
     }
   };
-
   return (
     <div className="relative h-full">
       <div className="relative flex h-full flex-col">
         <div className="custom-scrollable-element flex-1 overflow-y-auto px-4 pb-16 pt-3">
           <div className="mb-5 flex flex-col gap-3">
             <div className="flex items-center gap-3">
-              <button onClick={handleClickLeftIcon} className="h-7 w-7">
+              <Link href={`/challenge/${slug}/solutions?${queryString}`} className="h-7 w-7">
                 <div className="rounded-full p-1 hover:bg-gray-200 hover:bg-opacity-10">
                   <ArrowLeft className="stroke-gray-500" size={20} />
                 </div>
-              </button>
+              </Link>
               <div className="flex items-center gap-2">
                 <Avatar className="h-7 w-7">
                   <AvatarImage alt="github profile picture" src={solution.user?.image ?? ''} />

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
@@ -1,8 +1,8 @@
-import { useSearchParams } from "next/navigation";
+import { useSearchParams } from 'next/navigation';
 
-const useGetQueryString = ()=>{
-    const searchParams = useSearchParams();
-    const params = new URLSearchParams(searchParams);
-    return params.toString()
-}
-export default useGetQueryString
+const useGetQueryString = () => {
+  const searchParams = useSearchParams();
+  const params = new URLSearchParams(searchParams);
+  return params.toString();
+};
+export default useGetQueryString;

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
@@ -1,8 +1,7 @@
 import { useSearchParams } from 'next/navigation';
 
-const useGetQueryString = () => {
+export const useGetQueryString = () => {
   const searchParams = useSearchParams();
   const params = new URLSearchParams(searchParams);
   return params.toString();
 };
-export default useGetQueryString;

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useGetQueryString.tsx
@@ -1,0 +1,8 @@
+import { useSearchParams } from "next/navigation";
+
+const useGetQueryString = ()=>{
+    const searchParams = useSearchParams();
+    const params = new URLSearchParams(searchParams);
+    return params.toString()
+}
+export default useGetQueryString

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
@@ -2,7 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
-const useQueryParamState = <T extends number | string>(
+export const useQueryParamState = <T extends number | string>(
   key: string,
   defaultValue: T,
 ): [T, (value: T) => void] => {
@@ -26,5 +26,3 @@ const useQueryParamState = <T extends number | string>(
 
   return [value, setQueryParam];
 };
-
-export default useQueryParamState;

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
@@ -2,10 +2,7 @@
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
-export const useQueryParamState = <T extends number | string>(
-  key: string,
-  defaultValue: T,
-): [T, (value: T) => void] => {
+export const useQueryParamState = <T extends number | string>(key: string, defaultValue: T) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -24,5 +21,5 @@ export const useQueryParamState = <T extends number | string>(
     router.push(`${pathname}?${params.toString()}`);
   };
 
-  return [value, setQueryParam];
+  return [value, setQueryParam] as const;
 };

--- a/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
+++ b/apps/web/src/app/[locale]/challenge/[slug]/solutions/_components/useQueryParamState.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+
+const useQueryParamState = <T extends number | string>(
+  key: string,
+  defaultValue: T,
+): [T, (value: T) => void] => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const getValue = (): T => {
+    const value = searchParams.get(key);
+    if (!value) {
+      return defaultValue;
+    }
+    return (typeof defaultValue === 'number' ? Number(value) : value) as T;
+  };
+  const value = getValue();
+
+  const setQueryParam = (value: T) => {
+    const params = new URLSearchParams(searchParams);
+    params.set(key, value.toString());
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  return [value, setQueryParam];
+};
+
+export default useQueryParamState;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add page querystring to url when user navigating solution
Change to the browser's back action when pressing the back icon on the solution page.

## Related Issue
Closes #1325 

## Motivation and Context
After users view a solution on the Solutions page, they can return to the current page they were viewing.

## How Has This Been Tested?
When user press bottom navigation page param added to query string of url
When the filter is changed, the page changes to 1.
When the user sees the solution and go back user can return to the current page .
When user press the back icon on the solution page user can return to the current page they were viewing.

## Screenshots/Video (if applicable):

https://github.com/typehero/typehero/assets/62943813/4a9759ec-4677-419d-a6c3-62718f2d6887

