### PR TITLE
fix: remove `z-index` from header

### DIFF
--- a/apps/web/src/app/[locale]/_components/hero.tsx
+++ b/apps/web/src/app/[locale]/_components/hero.tsx
@@ -147,11 +147,11 @@ export async function Hero() {
   const t = await getScopedI18n('landing.hero');
   const session = await auth();
   return (
-    <section className="-mt-[56px] min-h-[calc(100vh)] overflow-hidden lg:min-h-0 lg:pt-[56px]">
+    <section className="pointer-events-none -mt-[56px] min-h-[calc(100vh)] overflow-hidden lg:min-h-0 lg:pt-[56px]">
       <div className="absolute inset-10 -z-30 overflow-hidden rounded-full opacity-70 lg:hidden">
         <BackgroundGrid />
       </div>
-      <div className="container relative grid min-h-screen items-center justify-center py-24 lg:min-h-0 lg:grid-cols-2 lg:py-0">
+      <div className="container relative grid min-h-screen items-center justify-center py-24 lg:min-h-0 lg:grid-cols-2 lg:py-0 [&>*]:pointer-events-auto">
         <BeamOfLight />
         <div className="flex w-full flex-col items-center justify-center gap-10 lg:items-start">
           <a

--- a/apps/web/src/components/Navigation/index.tsx
+++ b/apps/web/src/components/Navigation/index.tsx
@@ -77,7 +77,7 @@ export async function Navigation() {
   );
 
   return (
-    <header className="z-50 w-full">
+    <header className="w-full">
       <NavWrapper>
         <div className="flex w-full items-center justify-between">
           <div className="relative flex items-center gap-3">


### PR DESCRIPTION
## Description

This PR removes the `z-index` from the header, which is the cause of elements in the header clipping
through tooltips that show over it.

## Related Issue

N/A

## Motivation and Context

This was an issue on the challenge page, as the tooltips of the buttons that are at the top of the
code editor show up over the header.

## How Has This Been Tested?

I've confirmed that all the links and buttons in the header appears to work correctly without a
`z-index`, so it should be fine.

## Screenshots/Video (if applicable):

Before the change:

![image](https://github.com/typehero/typehero/assets/38114607/3988cc7e-ae32-4cc3-9117-b61b37d84c48)

After the change:

![image](https://github.com/typehero/typehero/assets/38114607/dc407d64-569e-4421-a1aa-2e500850cc95)
