### PR TITLE
Show Avent Of Code cards as links once they are flipped

### DIFF
--- a/apps/web/src/app/[locale]/aot-2023/_components/tiltable-card.tsx
+++ b/apps/web/src/app/[locale]/aot-2023/_components/tiltable-card.tsx
@@ -197,10 +197,13 @@ export function TiltableCard({ index, challenge }: Props) {
           </p>
         </motion.div>
       </motion.div>
-      <motion.div
+      <motion.a
+        href={`/challenge/${challenge.slug}`}
         onClick={(e) => {
           e.stopPropagation();
+          e.preventDefault();
           router.push(`/challenge/${challenge.slug}`);
+          return false;
         }}
         initial={{ rotateY: 180 }}
         animate={{ rotateY: isFlipped ? 0 : 180 }}
@@ -268,7 +271,7 @@ export function TiltableCard({ index, challenge }: Props) {
           )}
           <p className="text-xl font-bold text-white">{challenge.name}</p>
         </motion.div>
-      </motion.div>
+      </motion.a>
     </motion.div>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For context: see this tweet :
https://twitter.com/HugeLeters/status/1738596106034946139
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1344
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's an accessibility issue.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested it on local dev, i took care to prevent default so that the page don't fully reloads, but uses the router.
## Screenshots/Video (if applicable):
