### PR TITLE
fix: challenges tabs z-index fix

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/left-wrapper.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/left-wrapper.tsx
@@ -127,7 +127,7 @@ export function LeftWrapper({ children, challenge, track, expandPanel, isDesktop
       >
         <TabsList
           className={cn(
-            'bg-background/90 dark:bg-muted/90 sticky top-0 z-10 grid h-auto w-full border-b border-zinc-300 backdrop-blur-sm dark:border-zinc-700',
+            'bg-background/90 dark:bg-muted/90 sticky top-0 grid h-auto w-full border-b border-zinc-300 backdrop-blur-sm dark:border-zinc-700',
             {
               'grid-rows-3 gap-2': isIconOnly,
               'grid-cols-3 gap-0.5': !isIconOnly,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes z-index
## Description
<!--- Describe your changes in detail -->
removed the unneccesary z-index in challenges tabs in left-wrapper
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
![image](https://github.com/typehero/typehero/assets/114667178/1fc92904-3ad1-47b3-a3fc-89eca714a07e)

![image](https://github.com/typehero/typehero/assets/114667178/93835009-20d8-4026-aaa1-7830ab78037c)
