### PR TITLE
fix: fix header overlap on 404 page

### DIFF
--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -12,7 +12,7 @@ export default async function NotFound() {
 
   return (
     <>
-      <div className="relative -mt-[56px] flex h-screen flex-col items-center justify-center gap-8 overflow-hidden">
+      <div className="pointer-events-none relative -mt-[56px] flex h-screen flex-col items-center justify-center gap-8 overflow-hidden [&>*]:pointer-events-auto">
         <Image
           className="animate-amogfly absolute left-0 -z-10 mx-auto opacity-80"
           alt="Early Access"


### PR DESCRIPTION
## Description

This PR fixes the header not being clickable on the 404 page.

## Related Issue

N/A

## Motivation and Context

The fix is identical to what I did for the overlap on the landing page.

## How Has This Been Tested?

I tested this locally and can confirm that it works fine on both mobile and desktop.

## Screenshots/Video (if applicable):

https://github.com/typehero/typehero/assets/38114607/97b13a95-694a-44b0-b357-83b139f149fd