### PR TITLE
feat: copy button for markdown

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/overview.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/submissions/[[...catchAll]]/_components/overview.tsx
@@ -1,15 +1,13 @@
 import { Button } from '@repo/ui/components/button';
 import { Markdown } from '@repo/ui/components/markdown';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
-import { toast } from '@repo/ui/components/use-toast';
-import { CheckCircle2, Copy, Plus, Twitter, X, XCircle } from '@repo/ui/icons';
+import { CheckCircle2, Plus, Twitter, X, XCircle } from '@repo/ui/icons';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useParams, useSearchParams } from 'next/navigation';
 import { getRelativeTime } from '~/utils/relativeTime';
+import { AOT_CHALLENGES } from '../../../aot-slugs';
 import { getChallengeSubmissionById } from '../getChallengeSubmissions';
 import { Suggestions } from './suggestions';
-import { AOT_CHALLENGES } from '../../../aot-slugs';
 
 interface Props {
   submissionId: string;
@@ -35,16 +33,6 @@ export function SubmissionOverview({ submissionId }: Props) {
 
   const track = searchParams.get('slug');
 
-  const copyToClipboard = async () => {
-    if (navigator.clipboard) {
-      await navigator.clipboard.writeText(submission?.code ?? '').catch(console.error);
-      toast({
-        variant: 'success',
-        description: 'Copied!',
-      });
-    }
-  };
-
   if (!submission) return null;
 
   return (
@@ -53,16 +41,6 @@ export function SubmissionOverview({ submissionId }: Props) {
         <Link href={`/challenge/${slug}/submissions`}>
           <X className="stroke-gray-500 hover:stroke-gray-400" size={20} />
         </Link>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button onClick={copyToClipboard} variant="ghost">
-              <Copy className="stroke-gray-500 hover:stroke-gray-400" size={20} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Copy</p>
-          </TooltipContent>
-        </Tooltip>
       </div>
       <div className="custom-scrollable-element h-fit overflow-y-scroll p-2">
         <div className="mb-2 flex items-center justify-between">

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -1,14 +1,18 @@
 'use client';
 
+import clsx from 'clsx';
+import { useTheme } from 'next-themes';
+import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import remarkGfm from 'remark-gfm';
-import { vscDarkPlus } from '../themes/vs-dark-plus';
-import { vs } from '../themes/vs';
-import clsx from 'clsx';
-import { visit, SKIP, type BuildVisitor } from 'unist-util-visit';
 import type { Transformer } from 'unified';
-import { useTheme } from 'next-themes';
+import { SKIP, visit, type BuildVisitor } from 'unist-util-visit';
+import { vs } from '../themes/vs';
+import { vscDarkPlus } from '../themes/vs-dark-plus';
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
+import { Button } from './button';
+import { Check, Copy } from '../icons';
 // import rehypeRaw from 'rehype-raw';
 
 const HTML_COMMENT_REGEX = new RegExp('<!--([\\s\\S]*?)-->', 'g');
@@ -71,26 +75,29 @@ export function Markdown({ children, className }: { children: string; className?
         code({ inline, className, children, style: _, ...props }) {
           const match = /language-(\w+)/.exec(className || '');
           return !inline && match ? (
-            <SyntaxHighlighter
-              PreTag="section" // parent tag
-              className={clsx(className, 'rounded-xl dark:rounded-md')}
-              language={match[1]}
-              style={syntaxHighlighterTheme} // theme
-              customStyle={{ fontSize: 'inherit' }}
-              codeTagProps={{
-                style: {
-                  // overrides
-                  fontSize: 'inherit',
-                  lineHeight: 'inherit',
-                },
-                // This is required make it WCAG 2 compliant for scrolling through keyboard if the code overflows and have a scrollbar
-                // https://dequeuniversity.com/rules/axe/4.8/scrollable-region-focusable
-                tabIndex: 0,
-              }}
-              {...props}
-            >
-              {String(children).replace(/\n$/, '')}
-            </SyntaxHighlighter>
+            <div className="relative">
+              <CopyButton text={String(children).replace(/\n$/, '')} />
+              <SyntaxHighlighter
+                PreTag="section" // parent tag
+                className={clsx(className, 'rounded-xl dark:rounded-md')}
+                language={match[1]}
+                style={syntaxHighlighterTheme} // theme
+                customStyle={{ fontSize: 'inherit', padding: '30px' }}
+                codeTagProps={{
+                  style: {
+                    // overrides
+                    fontSize: 'inherit',
+                    lineHeight: 'inherit',
+                  },
+                  // This is required make it WCAG 2 compliant for scrolling through keyboard if the code overflows and have a scrollbar
+                  // https://dequeuniversity.com/rules/axe/4.8/scrollable-region-focusable
+                  tabIndex: 0,
+                }}
+                {...props}
+              >
+                {String(children).replace(/\n$/, '')}
+              </SyntaxHighlighter>
+            </div>
           ) : (
             <code className="rounded-md border border-zinc-300 bg-neutral-200 px-1 py-[0.10rem] font-mono text-zinc-600 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
               {children}
@@ -107,5 +114,46 @@ export function Markdown({ children, className }: { children: string; className?
     >
       {children}
     </ReactMarkdown>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copyToClipboard = async () => {
+    if (navigator.clipboard) {
+      await navigator.clipboard.writeText(text).catch(console.error);
+      setIsCopied(true);
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+    }
+  };
+
+  return (
+    <div className="absolute right-0">
+      {isCopied ? (
+        <div className="flex items-center justify-center p-3">
+          <Check className="stroke-green-500 hover:stroke-green-400" size={20} />
+        </div>
+      ) : (
+        <div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={copyToClipboard}
+                variant="ghost"
+                className="p-2 hover:bg-transparent dark:hover:bg-transparent"
+              >
+                <Copy className="stroke-gray-500 hover:stroke-gray-400" size={20} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Copy</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
adds copy button for code markdown snippets 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
![CleanShot 2023-12-28 at 11 06 27](https://github.com/typehero/typehero/assets/3660667/9fc0a3f1-b434-4eef-92dc-16611252b357)
![CleanShot 2023-12-28 at 11 08 06](https://github.com/typehero/typehero/assets/3660667/dc4451dd-a0cb-4d20-9908-18fbe09a5387)
