### PR TITLE
fix: no session return more-challenges only by difficulty

### DIFF
--- a/apps/web/src/utils/server/get-similar-challenges.ts
+++ b/apps/web/src/utils/server/get-similar-challenges.ts
@@ -23,6 +23,19 @@ export async function getSimilarChallenges(
       },
     });
 
+    if (!session) {
+      const challengesByDifficulty = await prisma.challenge.findMany({
+        where: {
+          difficulty,
+          id: {
+            notIn: [challengeId],
+          },
+        },
+        take: maxChallenges,
+      });
+      return challengesByDifficulty;
+    }
+
     const solvedSolutions = await prisma.submission.findMany({
       where: {
         userId: session?.user?.id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
when no session i am returning challengesByDifficulty and not including solved solution parameters in which session is required.
Also in notIn parameter passing the current challengeId so that same challenges should not be recommened again.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/typehero/typehero/issues/1383
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
![image](https://github.com/typehero/typehero/assets/114667178/c5ea3296-6d55-4239-8cbc-8a7a3e6912a3)
