### PR TITLE
fix: add the missing almostPi constant in literal-types challenge

### DIFF
--- a/challenges/literal-types/user.ts
+++ b/challenges/literal-types/user.ts
@@ -7,5 +7,6 @@ type LiteralFunction = unknown;
 const literalString = undefined;
 const literalTrue = undefined;
 const literalNumber = Math.random() > 0.5 ? undefined : undefined;
+const almostPi = undefined;
 const literalObject = {};
 const literalFunction = () => {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a test case about almostPi constant.
But there is no related declaration in the user input area.
That's very confusing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
