### PR TITLE
Add vim type hover focus update

### DIFF
--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -95,6 +95,17 @@ export default function SplitEditor({
   const inlayHintsProviderDisposableRef = useRef<monacoType.IDisposable>();
 
   useEffect(() => {
+    const keepEditorFocusedOnHoverCloseVim = (e: KeyboardEvent) => {
+      // In VIM mode, if the type hint hover is open, and we use the keyboard
+      // to close it, it's blured and nothing is focused anymore, so this
+      // is a workaround to keep the editor focused.
+      if (settings.bindings !== 'vim') {
+        return;
+      }
+      if (document.activeElement === document.body) { // nothing is focused
+        editorRef.current?.focus();
+      }
+    }
     const saveHandler = (e: KeyboardEvent) => {
       if (
         (e.ctrlKey || e.metaKey) &&
@@ -114,9 +125,11 @@ export default function SplitEditor({
     };
 
     document.addEventListener('keydown', saveHandler);
+    document.addEventListener('keydown', keepEditorFocusedOnHoverCloseVim);
 
     return () => {
       document.removeEventListener('keydown', saveHandler);
+      document.removeEventListener('keydown', keepEditorFocusedOnHoverCloseVim);
       inlayHintsProviderDisposableRef.current?.dispose();
     };
   }, [editorRef]);


### PR DESCRIPTION
## Description
I know this is a little hacky, def open to other ideas to look into. Basically, I think that if you use the keyboard shortcut to try to open the hover when it's already open, it does toggle to closed as you would expect, but when it's open it's focused, and when it toggles closed it doesn't refocus the editor element, instead nothing is focused. So this just focuses the editor if we're in vim mode and nothing is focused. 

## Related Issue
Closes #802 

## Motivation and Context
There's way more details and context in the issue linked above.

## How Has This Been Tested?
Run locally and tested.

## Screenshots/Video (if applicable):

https://github.com/typehero/typehero/assets/5819478/179a1fbe-4e61-4f27-9a6c-b47dc9e4feca

FYI @Hacksore 
