### PR TITLE
Filter out 'aot' challenge from getChallengeIds()

### DIFF
--- a/challenges/validate.ts
+++ b/challenges/validate.ts
@@ -74,6 +74,7 @@ const challengesDir = `${repoRoot}/challenges/`;
 export const getChallengeIds = () => {
   return readdirSync(challengesDir)
     .filter((id) => id !== 'blank')
+    .filter((id) => id !== 'aot')
     .filter((id) => statSync(join(challengesDir, id)).isDirectory())
     .filter((id) => statSync(join(challengesDir, id, 'metadata.json')).isFile())
     .filter((id) => statSync(join(challengesDir, id, 'tsconfig.json')).isFile());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is in regards to this [bug](https://github.com/typehero/typehero/issues/1174). At the moment the command is failing because it doesn't know how to handle `aot`, which has no metadata.json file.



## Related Issue
Issue: https://github.com/typehero/typehero/issues/1174

## Motivation and Context
On top, `aot` introduces a new pattern to the `challenges` folder, that didn't exist when `validate.ts` was written. If we are going to create seasonal challenges, and then add them to the `/challenges` directory as new directories, then the `validate.ts` code will probably need to be updated to handle this additional directory layer. 

This PR puts a band aide on the issue and allows users to run this `pnpm` command, although additional work will probably need to be done to address new aots, or any other seasonal challenges.

@bautistaaa ,

How would you like this to be addressed? Especially in terms of assumptions. Shall I just assume that we will be adding new aots for each year? Do you guys plan to do other seasonal challenges?

## How Has This Been Tested?
Yes, although If any additional work shall be done, I would suggest a baseline of test
<img width="732" alt="Screenshot 2024-01-24 at 10 08 53 AM" src="https://github.com/typehero/typehero/assets/76107997/601955b3-1a22-4188-8749-77df09014a04">
s to make sure that any changes in the directory pattern are caught during the GH workflow.

## Screenshots/Video (if applicable):
