### PR TITLE
fix: double problem explorer issue

### DIFF
--- a/apps/web/src/app/[locale]/challenge/[slug]/left-wrapper.tsx
+++ b/apps/web/src/app/[locale]/challenge/[slug]/left-wrapper.tsx
@@ -14,7 +14,6 @@ import { AOT_CHALLENGES } from './aot-slugs';
 import type { ChallengeRouteData } from './getChallengeRouteData';
 import { useTrackNavigationVisiblity } from './use-track-visibility.hook';
 import { ProblemExplorerTrackNav } from '~/components/Navigation/problem-explorer-track-nav';
-import { useProblemExplorerContext } from '~/app/problem-explorer.hooks';
 
 type Tab = 'description' | 'solutions' | 'submissions';
 interface Props {
@@ -29,7 +28,6 @@ export function LeftWrapper({ children, challenge, track, expandPanel, isDesktop
   const pathname = usePathname();
   const router = useRouter();
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const { isExplorerDisabled } = useProblemExplorerContext();
 
   const featureFlags = useContext(FeatureFlagContext);
 
@@ -120,12 +118,6 @@ export function LeftWrapper({ children, challenge, track, expandPanel, isDesktop
         />
       )}
       {Boolean(isTrackVisible && !hasEnrolledTrackForChallenge) && (
-        <ProblemExplorerTrackNav
-          isCollapsed={isCollapsed}
-          className={cn('border-b border-zinc-300 p-1 dark:border-zinc-700')}
-        />
-      )}
-      {Boolean(isTrackVisible && !isExplorerDisabled) && (
         <ProblemExplorerTrackNav
           isCollapsed={isCollapsed}
           className={cn('border-b border-zinc-300 p-1 dark:border-zinc-700')}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When not enrolled from any track, two problem explorer were popping up,
Removed the old boolean statement which used to check whether explorer is disabled or not,
and showed the ui for problem explorer, now it just checks whether the currect problem is a track challenge or not which is null if user is not enrolled in any track automatically
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
