### PR TITLE
feat: show challenges that have not been completed first

### DIFF
--- a/apps/web/src/app/[locale]/explore/_components/explore-slug.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-slug.tsx
@@ -13,13 +13,23 @@ interface ExploreSlugProps {
 export async function ExploreSlug({ slug }: ExploreSlugProps) {
   const challenges = await getChallengesByTagOrDifficulty(slug);
 
+  const sortedChallenges = challenges.sort((a, b) => {
+    const aHasSuccessfulSubmission = a?.submission?.some((submission) => submission.isSuccessful);
+    const bHasSubmission = b?.submission?.some((submission) => submission.isSuccessful);
+
+    if (aHasSuccessfulSubmission && !bHasSubmission) return 1;
+    if (!aHasSuccessfulSubmission && bHasSubmission) return -1;
+
+    return 0;
+  });
+
   return (
     <div className="container flex flex-col items-center gap-8 py-5 md:gap-16 md:pb-20">
       <div className="flex space-y-2">
         <TypographyH3>{toPascalCase(slug)}</TypographyH3>
       </div>
       <div className="flex w-full flex-wrap justify-center gap-6">
-        {challenges.map((challenge) => (
+        {sortedChallenges.map((challenge) => (
           <Link
             className="group block w-[95%] focus:outline-none sm:w-[330px] xl:w-[333px]"
             href={`/challenge/${challenge.slug}`}

--- a/apps/web/src/app/[locale]/explore/_components/explore-slug.tsx
+++ b/apps/web/src/app/[locale]/explore/_components/explore-slug.tsx
@@ -15,10 +15,10 @@ export async function ExploreSlug({ slug }: ExploreSlugProps) {
 
   const sortedChallenges = challenges.sort((a, b) => {
     const aHasSuccessfulSubmission = a?.submission?.some((submission) => submission.isSuccessful);
-    const bHasSubmission = b?.submission?.some((submission) => submission.isSuccessful);
+    const bHasSuccessfulSubmission = b?.submission?.some((submission) => submission.isSuccessful);
 
-    if (aHasSuccessfulSubmission && !bHasSubmission) return 1;
-    if (!aHasSuccessfulSubmission && bHasSubmission) return -1;
+    if (aHasSuccessfulSubmission && !bHasSuccessfulSubmission) return 1;
+    if (!aHasSuccessfulSubmission && bHasSuccessfulSubmission) return -1;
 
     return 0;
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On the explore page for a challenge (see [hard](https://typehero.dev/explore/hard)), I would like the challenges that have not been solved to be shown first.

## Description
I added a sort to the list of challenges returned from the query that pushes the completed challenges to the bottom

## Related Issue
Closes #1427

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1427

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Screenshots/Video (if applicable):
<img width="1710" alt="Screenshot 2024-04-12 at 07 30 52" src="https://github.com/typehero/typehero/assets/46367335/84004513-c712-431b-8e4f-e5b662d3e326">
