### PR TITLE
feat: scroll on left side pane

### DIFF
--- a/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
@@ -92,7 +92,7 @@ export function Description({ challenge }: Props) {
     <div
       className="custom-scrollable-element h-full overflow-y-auto px-4 pb-36 pt-3 focus:outline-none"
       ref={descriptionRef}
-      tabIndex={0}
+      tabIndex={-1}
     >
       <div className="flex items-center">
         <TypographyH3 className="mr-auto max-w-[75%] items-center truncate text-2xl font-bold">

--- a/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
+++ b/apps/web/src/app/[locale]/challenge/_components/description/index.tsx
@@ -20,7 +20,7 @@ import { Bookmark as BookmarkIcon, Calendar, CheckCircle, Flag, Share } from '@r
 import clsx from 'clsx';
 import { debounce } from 'lodash';
 import Link from 'next/link';
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import { type ChallengeRouteData } from '~/app/[locale]/challenge/[slug]/getChallengeRouteData';
 import { ReportDialog } from '~/components/ReportDialog';
 import { getRelativeTime } from '~/utils/relativeTime';
@@ -43,6 +43,7 @@ export interface FormValues {
 
 export function Description({ challenge }: Props) {
   const [hasBookmarked, setHasBookmarked] = useState(challenge.bookmark.length > 0);
+  const descriptionRef = useRef<HTMLDivElement | null>(null);
   const session = useSession();
 
   const isAotChallenge = useMemo(() => AOT_CHALLENGES.includes(challenge.slug), [challenge.slug]);
@@ -60,8 +61,39 @@ export function Description({ challenge }: Props) {
     }, 500),
   ).current;
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const ref = descriptionRef.current;
+      const scrollAmount = 50;
+
+      if (!ref) return;
+
+      if (ref.contains(document.activeElement)) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          ref.scrollBy({ top: scrollAmount, behavior: 'smooth' });
+        }
+
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          ref.scrollBy({ top: -scrollAmount, behavior: 'smooth' });
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   return (
-    <div className="custom-scrollable-element h-full overflow-y-auto px-4 pb-36 pt-3">
+    <div
+      className="custom-scrollable-element h-full overflow-y-auto px-4 pb-36 pt-3 focus:outline-none"
+      ref={descriptionRef}
+      tabIndex={0}
+    >
       <div className="flex items-center">
         <TypographyH3 className="mr-auto max-w-[75%] items-center truncate text-2xl font-bold">
           {challenge.name}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the left side pane is focused, users aren't able to scroll down or up using the arrow keys

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1392 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Added `keydown` event listener to the description pane when it's focused to be scrollable.
- Div elements require the `tabIndex` attribute to be focusable with the value of `-1` to prevent the element from being navigated directly using the tab key.

## Screenshots/Video (if applicable):
### Before
https://github.com/user-attachments/assets/61afa035-e182-4280-927a-14ba9d827b72
### After
https://github.com/user-attachments/assets/73c3d48e-57c6-4f5f-ad94-aff5b30bfba4

