### PR TITLE
fix: challenge ten type typo

### DIFF
--- a/challenges/aot/2023/10/user.ts
+++ b/challenges/aot/2023/10/user.ts
@@ -1,1 +1,1 @@
-type StreetSufixTester = unknown;
+type StreetSuffixTester = unknown;


### PR DESCRIPTION
## Description
Basic starting type typo fix on challenge 10.

## Related Issue
https://github.com/typehero/typehero/issues/1431

Closes #1431
