### PR TITLE
Fix: check 'window' object using typeof in useLocalStorage hook

### DIFF
--- a/apps/web/src/utils/useLocalStorage.ts
+++ b/apps/web/src/utils/useLocalStorage.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export function useLocalStorage(key: string, initialValue: string): [string, (v: string) => void] {
   const [storedValue, setStoredValue] = useState<string>(() => {
     try {
-      if (window !== undefined) {
+      if (typeof window !== 'undefined') {
         return window.localStorage.getItem(key) || initialValue;
       }
       return initialValue;


### PR DESCRIPTION
## Description
Checking if `window` object exists using `typeof` to prevent reference error on server.

## Related Issue
Closes #1467 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Avoid reference error for `window` object when a page using `useLocalStorage` hook is partially rendered on server.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1467 

## How Has This Been Tested?
Visited home page.