### PR TITLE
fix: Prevent '0' being passed as the page param to paginated solution comments api

### DIFF
--- a/apps/web/src/app/challenge/_components/comments/comments.hooks.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comments.hooks.tsx
@@ -93,7 +93,10 @@ export function useComments({ type, rootId, initialPage }: UseCommentsProps) {
           description: 'The comment was successfully deleted.',
         });
       }
-      const newPage = data?.comments.length === 1 && commentsMeta.page > 1 ? commentsMeta.page - 1 : commentsMeta.page;
+      const newPage =
+        data?.comments.length === 1 && commentsMeta.page > 1
+          ? commentsMeta.page - 1
+          : commentsMeta.page;
       changePage(newPage);
       queryClient.invalidateQueries({
         queryKey: getQueryKey({ sort: commentsMeta.sort.value, page: newPage }),

--- a/apps/web/src/app/challenge/_components/comments/comments.hooks.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comments.hooks.tsx
@@ -93,7 +93,7 @@ export function useComments({ type, rootId, initialPage }: UseCommentsProps) {
           description: 'The comment was successfully deleted.',
         });
       }
-      const newPage = data?.comments.length === 1 ? commentsMeta.page - 1 : commentsMeta.page;
+      const newPage = data?.comments.length === 1 && commentsMeta.page > 1 ? commentsMeta.page - 1 : commentsMeta.page;
       changePage(newPage);
       queryClient.invalidateQueries({
         queryKey: getQueryKey({ sort: commentsMeta.sort.value, page: newPage }),

--- a/apps/web/src/app/challenge/_components/comments/getCommentRouteData.ts
+++ b/apps/web/src/app/challenge/_components/comments/getCommentRouteData.ts
@@ -134,7 +134,7 @@ export async function getPaginatedComments({
   });
 
   const comments = await prisma.comment.findMany({
-    skip: (page - 1) * take,
+    skip: ((page || 1) - 1) * take,
     take,
     where: {
       rootType,

--- a/apps/web/src/components/Navigation/index.tsx
+++ b/apps/web/src/components/Navigation/index.tsx
@@ -1,5 +1,4 @@
 import { type Session } from '@repo/auth/server';
-import { Badge } from '@repo/ui/components/badge';
 import {
   DropdownMenu,
   DropdownMenuContent,


### PR DESCRIPTION
## Description
Added checks to prevent a value of 0 from being passed as the page parameter for the paginated solution comments API.

## Related Issue
Fixes #1504

## Motivation and Context
When deleting the last comment on a solution, the client was fetching paginated comments with a page parameter value of 0. I have added checks on the client to prevent invalid values from being passed to the API call. Additionally, I have added a check on the server to prevent negative values from being passed as the `skip` parameter for Prisma.

## How Has This Been Tested?
Tested by deleting the last comment on a solution, ensuring that the request made to the server contains a page parameter value of 1.

## Screenshots:
Last Comment:
![image](https://github.com/user-attachments/assets/f5c5ce04-a1ec-4ba0-ad4a-477f6a76b226)

Proper page parameter passed:
![image](https://github.com/user-attachments/assets/f8729241-3235-41fd-ab4b-69aa7b441e5a)
