### PR TITLE
Fix root to be ESM 😵

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "typehero",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "turbo build",
     "checks": "turbo format lint typecheck --continue",


### PR DESCRIPTION
should fix:

```
Run npx tsx tooling/scripts/contributors.ts

node:internal/process/esm_loader:40
      internalBinding('errors').triggerUncaughtException(
                                ^
Error: tsx must be loaded with --import instead of --loader
The --loader flag was deprecated in Node v20.6.0
    at X (file:///home/runner/work/typehero/typehero/node_modules/tsx/dist/esm/index.mjs:1:1920)
    at Hooks.addCustomLoader (node:internal/modules/esm/hooks:202:24)
    at Hooks.register (node:internal/modules/esm/hooks:16[8](https://github.com/typehero/typehero/actions/runs/10623717194/job/29450679042#step:4:9):16)
    at async initializeHooks (node:internal/modules/esm/utils:233:5)
    at async customizedModuleWorker (node:internal/modules/esm/worker:[10](https://github.com/typehero/typehero/actions/runs/10623717194/job/29450679042#step:4:11)4:24)
```