### PR TITLE
change: load monaco from cdn

### DIFF
--- a/packages/monaco/src/code-editor.tsx
+++ b/packages/monaco/src/code-editor.tsx
@@ -5,24 +5,9 @@ import { useTheme } from 'next-themes';
 import { useMemo } from 'react';
 import { useEditorSettingsStore } from './settings-store';
 
-const ADMIN_HOST = 'admin.typehero.dev';
-const getBaseUrl = () => {
-  if (typeof globalThis.window === 'undefined') return '';
-  const isProd = process.env.NODE_ENV === 'production';
-  if (isProd && window?.location?.hostname === ADMIN_HOST) {
-    return 'https://typehero.dev';
-  }
-
-  if (!isProd && window?.location?.port === '3001') {
-    return 'http://localhost:3000';
-  }
-
-  return '';
-};
-
 loader.config({
   paths: {
-    vs: `${getBaseUrl()}/min/vs`,
+    vs: `https://playgroundcdn.typescriptlang.org/cdn/5.5.4/monaco/min/vs`,
   },
 });
 


### PR DESCRIPTION
Looked through the source code of the [loader](https://github.com/suren-atoyan/monaco-loader?tab=readme-ov-file#init) and compared it to some other playgrounds. It appears you can just link the `loader.js` from the CDN directly.

Prior, we were running a script that would download all of monaco and TS and place them in our `public` folder. It appears that was unnecessary. 

Hoping I can dynamically change the TS version in the playground and reload the playground accordingly