### PR TITLE
feat: add back button on challenge page

### DIFF
--- a/apps/web/src/components/Navigation/problem-explorer-track-nav.tsx
+++ b/apps/web/src/components/Navigation/problem-explorer-track-nav.tsx
@@ -4,16 +4,18 @@ import { useMemo } from 'react';
 import { ExploreDrawer } from '~/app/challenge/_components/explore-drawer';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip';
 import Link from 'next/link';
-import { ChevronLeft, ChevronRight, Swords } from '@repo/ui/icons';
+import { ArrowLeft, ChevronLeft, ChevronRight, Swords } from '@repo/ui/icons';
 import { cn } from '@repo/ui/cn';
 import { Button } from '@repo/ui/components/button';
 import { useChallengeRouteData } from '~/app/challenge/[slug]/challenge-route-data.hook';
+import { useRouter } from 'next/navigation';
 
 interface ProblemExplorerTrackNav {
   isCollapsed: boolean;
   className?: string;
 }
 export function ProblemExplorerTrackNav({ isCollapsed, className }: ProblemExplorerTrackNav) {
+  const router = useRouter();
   const { currentChallenge } = useChallengeRouteData();
   const { getTrack, title } = useProblemExplorerContext();
   const track = getTrack;
@@ -50,11 +52,23 @@ export function ProblemExplorerTrackNav({ isCollapsed, className }: ProblemExplo
         className,
       )}
     >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => router.back()}
+        className={cn('rounded-tl-xl', {
+          'justify-start': !isCollapsed,
+          'h-full items-center justify-center p-4 hover:bg-neutral-200/50 dark:hover:bg-neutral-700/50':
+            isCollapsed,
+        })}
+      >
+        <ArrowLeft className="h-4 w-4" />
+      </Button>
       <ExploreDrawer asChild>
         <Button
           variant="ghost"
           size="sm"
-          className={cn('inline-flex flex-1 gap-2 overflow-hidden rounded-tl-xl', {
+          className={cn('inline-flex flex-1 gap-2 overflow-hidden', {
             'justify-start': !isCollapsed,
             'h-full items-center justify-center p-4 hover:bg-neutral-200/50 dark:hover:bg-neutral-700/50':
               isCollapsed,


### PR DESCRIPTION
## Description
Added a back button on the challenge page

## Related Issue
Closes #1335 

## Motivation and Context
Fixes #1335 

## How Has This Been Tested?
Tested my changes on Google Chrome latest version. Should not need rigorous browser testing since it's a minor change.

## Screenshots/Video (if applicable):
<img width="1781" alt="image" src="https://github.com/user-attachments/assets/13fcf436-f3f6-4a69-abf9-5a9bea550ce3">
