### PR TITLE
Adds functionality to reply to replies

### DIFF
--- a/apps/web/src/app/challenge/_components/comments/comment-input.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comment-input.tsx
@@ -1,13 +1,20 @@
-import { Loader2 } from '@repo/ui/icons';
-import { useSession } from '@repo/auth/react';
-import { useEffect, useRef, useState, type RefObject } from 'react';
-import { Button } from '@repo/ui/components/button';
-import { Markdown } from '@repo/ui/components/markdown';
-import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useSession } from '@repo/auth/react';
+import { Button } from '@repo/ui/components/button';
 import { Form, FormField, FormItem, FormMessage } from '@repo/ui/components/form';
-import { singleFieldSchema, type SingleFieldSchema } from '~/utils/zodSingleStringField';
+import { Markdown } from '@repo/ui/components/markdown';
+import { Loader2 } from '@repo/ui/icons';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+import { useForm } from 'react-hook-form';
 import { MentionInput } from '~/components/mention/mention-input';
+import { singleFieldSchema, type SingleFieldSchema } from '~/utils/zodSingleStringField';
 
 interface Props {
   mode: 'create' | 'edit' | 'reply';
@@ -17,103 +24,122 @@ interface Props {
   defaultValue?: string;
 }
 
-export function CommentInput({ mode, onCancel, placeholder, onSubmit, defaultValue }: Props) {
-  const { data: session } = useSession();
-  const [commentMode, setCommentMode] = useState<'editor' | 'preview'>('editor');
+interface CommentInputRefProps {
+  textarea: HTMLTextAreaElement;
+  setInputValue: (value: string) => void;
+}
 
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+export const CommentInput = forwardRef<CommentInputRefProps, Props>(
+  ({ mode, onCancel, placeholder, onSubmit, defaultValue }: Props, ref) => {
+    const { data: session } = useSession();
+    const [commentMode, setCommentMode] = useState<'editor' | 'preview'>('editor');
 
-  const form = useForm<SingleFieldSchema>({
-    resolver: zodResolver(singleFieldSchema),
-    defaultValues: { text: defaultValue ?? '' },
-  });
-  const formValid = form.formState.isValid;
-  const value = form.watch('text');
-  useAutosizeTextArea(textAreaRef, value, commentMode);
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const submitComment = async ({ text }: { text: string }) => {
-    try {
-      await onSubmit(text);
-    } catch (e) {
-      console.error(e);
-    } finally {
-      form.reset();
-      setCommentMode('editor');
-    }
-  };
+    const form = useForm<SingleFieldSchema>({
+      resolver: zodResolver(singleFieldSchema),
+      defaultValues: { text: defaultValue ?? '' },
+    });
 
-  const isSubmitting = form.formState.isSubmitting;
+    // We need to control the textarea element from parent component.
+    useImperativeHandle(ref, () => ({
+      textarea: textAreaRef?.current!,
+      setInputValue: (value: string) => {
+        form.setValue('text', value);
+        form.trigger();
+      },
+    }));
 
-  return (
-    <div className="relative flex flex-col">
-      {commentMode === 'editor' && (
-        <div className="rounded-xl rounded-br-lg bg-neutral-100 backdrop-blur-sm dark:border-zinc-700 dark:bg-zinc-700/90">
-          <Form {...form}>
-            <FormField
-              control={form.control}
-              name="text"
-              render={({ field }) => (
-                <FormItem>
-                  <MentionInput
-                    disabled={!session?.user}
-                    autoFocus
-                    className="resize-none border-0 px-3 py-2 focus-visible:ring-0 md:max-h-[calc(100vh_-_232px)]"
-                    onChange={(e) => {
-                      field.onChange(e);
-                      form.trigger();
-                    }}
-                    onKeyDown={(e) => {
-                      if (isSubmitting) {
-                        e.preventDefault();
+    const formValid = form.formState.isValid;
+    const value = form.watch('text');
+
+    useAutosizeTextArea(textAreaRef, value, commentMode);
+
+    const submitComment = async ({ text }: { text: string }) => {
+      try {
+        await onSubmit(text);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        form.reset();
+        setCommentMode('editor');
+      }
+    };
+
+    const isSubmitting = form.formState.isSubmitting;
+
+    return (
+      <div className="relative flex flex-col">
+        {commentMode === 'editor' && (
+          <div className="rounded-xl rounded-br-lg bg-neutral-100 backdrop-blur-sm dark:border-zinc-700 dark:bg-zinc-700/90">
+            <Form {...form}>
+              <FormField
+                control={form.control}
+                name="text"
+                render={({ field }) => (
+                  <FormItem>
+                    <MentionInput
+                      disabled={!session?.user}
+                      autoFocus
+                      className="resize-none border-0 px-3 py-2 focus-visible:ring-0 md:max-h-[calc(100vh_-_232px)]"
+                      onChange={(e) => {
+                        field.onChange(e);
+                        form.trigger();
+                      }}
+                      onKeyDown={(e) => {
+                        if (isSubmitting) {
+                          e.preventDefault();
+                        }
+                      }}
+                      placeholder={
+                        placeholder ?? !session?.user
+                          ? 'You need to be logged in to comment.'
+                          : 'Enter your comment here.'
                       }
-                    }}
-                    placeholder={
-                      placeholder ?? !session?.user
-                        ? 'You need to be logged in to comment.'
-                        : 'Enter your comment here.'
-                    }
-                    forwardedref={textAreaRef}
-                    value={value}
-                  />
-                  <FormMessage className="absolute h-8 pl-3 leading-8" />
-                </FormItem>
-              )}
-            />
-          </Form>
-        </div>
-      )}
-      {commentMode === 'preview' && (
-        <div className="min-h-[5rem] overflow-y-auto break-words px-3 pt-2 text-sm md:max-h-[calc(100vh_-_232px)]">
-          <Markdown>{value}</Markdown>
-        </div>
-      )}
-      <div className="flex justify-end">
-        <div className="flex gap-2 p-2 pl-0">
-          <Button
-            className="h-8"
-            disabled={isSubmitting || value.length === 0}
-            onClick={() => setCommentMode(commentMode === 'editor' ? 'preview' : 'editor')}
-            variant={mode === 'create' ? 'secondary' : 'ghost'}
-          >
-            {commentMode === 'editor' ? 'Preview' : 'Edit'}
-          </Button>
-          {mode !== 'create' && (
-            <Button className="h-8" onClick={() => onCancel?.()} variant="secondary">
-              Cancel
+                      forwardedref={textAreaRef}
+                      value={value}
+                    />
+                    <FormMessage className="absolute h-8 pl-3 leading-8" />
+                  </FormItem>
+                )}
+              />
+            </Form>
+          </div>
+        )}
+        {commentMode === 'preview' && (
+          <div className="min-h-[5rem] overflow-y-auto break-words px-3 pt-2 text-sm md:max-h-[calc(100vh_-_232px)]">
+            <Markdown>{value}</Markdown>
+          </div>
+        )}
+        <div className="flex justify-end">
+          <div className="flex gap-2 p-2 pl-0">
+            <Button
+              className="h-8"
+              disabled={isSubmitting || value.length === 0}
+              onClick={() => setCommentMode(commentMode === 'editor' ? 'preview' : 'editor')}
+              variant={mode === 'create' ? 'secondary' : 'ghost'}
+            >
+              {commentMode === 'editor' ? 'Preview' : 'Edit'}
             </Button>
-          )}
-          <Button
-            className="h-8 w-[5.5rem] rounded-lg rounded-br-sm"
-            disabled={value.length === 0 || isSubmitting || !formValid}
-            onClick={form.handleSubmit(submitComment)}
-          >
-            {isSubmitting ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Comment'}
-          </Button>
+            {mode !== 'create' && (
+              <Button className="h-8" onClick={() => onCancel?.()} variant="secondary">
+                Cancel
+              </Button>
+            )}
+            <Button
+              className="h-8 w-[5.5rem] rounded-lg rounded-br-sm"
+              disabled={value.length === 0 || isSubmitting || !formValid}
+              onClick={form.handleSubmit(submitComment)}
+            >
+              {isSubmitting ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Comment'}
+            </Button>
+          </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);
+CommentInput.displayName = `CommentInput`;
 
 function useAutosizeTextArea(
   textAreaRef: RefObject<HTMLTextAreaElement>,

--- a/apps/web/src/app/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comment.tsx
@@ -127,22 +127,6 @@ export function Comment({
         deleteComment={deleteComment}
         updateComment={updateComment}
       />
-      {isReplying ? (
-        <div className="relative mt-2 pb-2 pl-8">
-          <Reply className="absolute left-2 top-2 h-4 w-4 opacity-50" />
-          <CommentInput
-            mode="edit"
-            onCancel={() => {
-              setIsReplying(false);
-            }}
-            onSubmit={async (text) => {
-              await addReplyComment(text);
-              setShowReplies(true);
-              setIsReplying(false);
-            }}
-          />
-        </div>
-      ) : null}
 
       {showReplies && status === 'pending' ? <CommentSkeleton /> : null}
       {showReplies ? (
@@ -158,6 +142,7 @@ export function Comment({
                   preselectedCommentMetadata={preselectedCommentMetadata}
                   deleteComment={deleteReplyComment}
                   updateComment={updateReplyComment}
+                  onClickReply={toggleIsReplying}
                 />
               )),
             )}
@@ -174,6 +159,23 @@ export function Comment({
             </Button>
           ) : null}
         </>
+      ) : null}
+
+      {isReplying ? (
+        <div className="relative mt-2 pb-2 pl-8">
+          <Reply className="absolute left-2 top-2 h-4 w-4 opacity-50" />
+          <CommentInput
+            mode="edit"
+            onCancel={() => {
+              setIsReplying(false);
+            }}
+            onSubmit={async (text) => {
+              await addReplyComment(text);
+              setShowReplies(true);
+              setIsReplying(false);
+            }}
+          />
+        </div>
       ) : null}
     </div>
   );
@@ -323,19 +325,17 @@ function SingleComment({
                   }}
                 />
 
-                {!isReply && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button variant="secondary" size="xs" onClick={onClickReply}>
-                        <Reply className="h-3 w-3" />
-                        <span className="sr-only">Create a reply</span>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Reply</p>
-                    </TooltipContent>
-                  </Tooltip>
-                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="secondary" size="xs" onClick={onClickReply}>
+                      <Reply className="h-3 w-3" />
+                      <span className="sr-only">Create a reply</span>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Reply</p>
+                  </TooltipContent>
+                </Tooltip>
               </div>
 
               <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">

--- a/apps/web/src/app/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comment.tsx
@@ -344,7 +344,7 @@ function SingleComment({
 
       <div className="flex gap-3">
         <ExpandableContent content={comment.text} />
-        <div className="flex flex-col items-end gap-2">
+        <div className="flex flex-col items-end">
           {!readonly && (
             <>
               <div className="flex gap-1">
@@ -385,118 +385,116 @@ function SingleComment({
                   </TooltipContent>
                 </Tooltip>
               </div>
-
-              <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                <div>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="secondary"
-                        size="xs"
-                        className="gap-2"
-                        onClick={() => {
-                          copyPathNotifyUser(Boolean(isReply), slug as string);
-                        }}
-                      >
-                        <Share className="h-3 w-3" />
-                        <span className="sr-only">Share this comment</span>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Share</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-
-                <div>
-                  {isAuthor ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="secondary"
-                          size="xs"
-                          onClick={() => setIsEditing(!isEditing)}
-                        >
-                          <Pencil className="h-3 w-3" />
-                          <span className="sr-only">Edit this comment</span>
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>Edit</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                </div>
-
-                <div>
-                  {isAuthor || isAdminAndModerator ? (
-                    <Tooltip>
-                      <CommentDeleteDialog asChild comment={comment} deleteComment={deleteComment}>
-                        <TooltipTrigger asChild>
-                          <Button variant="secondary" size="xs">
-                            <Trash2 className="h-3 w-3" />
-                            <span className="sr-only">Delete this comment</span>
-                          </Button>
-                        </TooltipTrigger>
-                      </CommentDeleteDialog>
-                      <TooltipContent>
-                        <p>Delete</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <Tooltip>
-                      <ReportDialog triggerAsChild commentId={comment.id} reportType="COMMENT">
-                        <TooltipTrigger asChild>
-                          <Button variant="secondary" size="xs">
-                            <Flag className="h-3 w-3" />
-                            <span className="sr-only">Report this comment</span>
-                          </Button>
-                        </TooltipTrigger>
-                      </ReportDialog>
-                      <TooltipContent>
-                        <p>Report</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              </div>
             </>
           )}
         </div>
       </div>
 
-      {!isEditing && (
-        <div className="mb-2 mt-1.5 flex justify-between">
-          {hasBeenEdited ? (
-            <div className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs">
-              Last edited at{' '}
-              {new Intl.DateTimeFormat(undefined, {
-                timeStyle: 'short',
-                dateStyle: 'short',
-              }).format(comment.updatedAt)}
-            </div>
-          ) : null}
-          {comment._count.replies > 0 && (
-            <Button
-              variant="ghost"
-              size="xs"
-              className="z-50 ml-auto gap-1"
-              onClick={onClickToggleReply}
-            >
-              {isToggleReply ? (
-                <ChevronDown className="h-4 w-4" />
-              ) : (
-                <ChevronUp className="h-4 w-4" />
-              )}
+      <div className="mb-2 flex flex-row flex-wrap items-center justify-between">
+        {!isEditing && (
+          <div className="flex gap-4">
+            {comment._count.replies > 0 && (
+              <Button
+                variant="secondary"
+                size="xs"
+                className="z-50 gap-1"
+                onClick={onClickToggleReply}
+              >
+                {isToggleReply ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronUp className="h-4 w-4" />
+                )}
 
-              <div className="text-xs">
-                {comment._count.replies === 1 ? '1 reply' : `${comment._count.replies} replies`}
+                <div className="text-xs">
+                  {comment._count.replies === 1 ? '1 reply' : `${comment._count.replies} replies`}
+                </div>
+                <span className="sr-only">Toggle replies view</span>
+              </Button>
+            )}
+            {hasBeenEdited ? (
+              <div className="text-muted-foreground flex items-center gap-2 whitespace-nowrap text-xs">
+                Last edited at{' '}
+                {new Intl.DateTimeFormat(undefined, {
+                  timeStyle: 'short',
+                  dateStyle: 'short',
+                }).format(comment.updatedAt)}
               </div>
-              <span className="sr-only">Toggle replies view</span>
-            </Button>
-          )}
+            ) : null}
+          </div>
+        )}
+        <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  className="gap-2"
+                  onClick={() => {
+                    copyPathNotifyUser(Boolean(isReply), slug as string);
+                  }}
+                >
+                  <Share className="h-3 w-3" />
+                  <span className="sr-only">Share this comment</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Share</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          <div>
+            {isAuthor ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="secondary" size="xs" onClick={() => setIsEditing(!isEditing)}>
+                    <Pencil className="h-3 w-3" />
+                    <span className="sr-only">Edit this comment</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Edit</p>
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+
+          <div>
+            {isAuthor || isAdminAndModerator ? (
+              <Tooltip>
+                <CommentDeleteDialog asChild comment={comment} deleteComment={deleteComment}>
+                  <TooltipTrigger asChild>
+                    <Button variant="secondary" size="xs">
+                      <Trash2 className="h-3 w-3" />
+                      <span className="sr-only">Delete this comment</span>
+                    </Button>
+                  </TooltipTrigger>
+                </CommentDeleteDialog>
+                <TooltipContent>
+                  <p>Delete</p>
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Tooltip>
+                <ReportDialog triggerAsChild commentId={comment.id} reportType="COMMENT">
+                  <TooltipTrigger asChild>
+                    <Button variant="secondary" size="xs">
+                      <Flag className="h-3 w-3" />
+                      <span className="sr-only">Report this comment</span>
+                    </Button>
+                  </TooltipTrigger>
+                </ReportDialog>
+                <TooltipContent>
+                  <p>Report</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
         </div>
-      )}
+      </div>
+
       {isEditing ? (
         <div className="mb-2">
           <CommentInput

--- a/apps/web/src/app/challenge/_components/comments/comment.tsx
+++ b/apps/web/src/app/challenge/_components/comments/comment.tsx
@@ -121,6 +121,7 @@ export function Comment({
 
     setShowReplies(!showReplies);
   };
+  const toggleIsReplying = () => setIsReplying(!isReplying);
 
   const commentInputRef = useRef<{
     textarea: HTMLTextAreaElement;
@@ -165,7 +166,7 @@ export function Comment({
         preselectedCommentMetadata={preselectedCommentMetadata}
         comment={comment}
         isToggleReply={showReplies}
-        onClickReply={(replyingTo) => showReplyInput(replyingTo)}
+        onClickReply={toggleIsReplying}
         onClickToggleReply={toggleReplies}
         readonly={readonly}
         deleteComment={deleteComment}


### PR DESCRIPTION
## Description
As of now, you could only reply to parent comment. 
This PR adds the functionality to be able to add sibling comments to other replies. Additionally, when you reply to another reply comment, the "username" tag of the user you are replying to gets autofilled in the input for better UX.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1605 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The website was a bit restrictive and inconsistent where you could only reply to original comments -- this functionality was disabled in case of reply comments.  The PR adds functionality of adding comments to replies as "sibling comments" and also referencing the "recipient" of the reply for better UX.

## Implementation
I've exposed two things -- textarea element and a function to set the input value out of `CommentInput` component to control it from the parent component -- `Comment`.
- We use `setInputValue` to dynamically pass the username in a reply.
- We use the textarea element ref to control "focus" and "scroll".
- clicking on reply button shows the input + prefills the input with the `replyingTo` username.
- it also handles the edge case -- clicking on reply again when input is open should refill the input with the username.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested this locally on http://localhost:3000/challenge/get-return-type which has over 150 comments. I've tested the following scenarios:
- Reply button should be visible on every comment ✅
- Clicking on reply button should display the reply text area ✅
- reply text area should auto fill the name of the user you are replying to ✅
- clicking on reply again when the input is open should re-fill the username ✅

## Screenshots/Video (if applicable):
https://github.com/user-attachments/assets/903e3b49-bc62-471f-8023-4b3243c8bfd3

