### PR TITLE
fix day numbers and also make query to get challenges much more succinct

### DIFF
--- a/apps/aot/src/app/events/[year]/page.tsx
+++ b/apps/aot/src/app/events/[year]/page.tsx
@@ -12,7 +12,7 @@ import BgDecorations from './24BgDecorations';
 import DayInactive from './day-inactive';
 import type { RouterOutputs } from '~/trpc/react';
 
-type Challenge = RouterOutputs['event']['getEventChallengesByYear'][0];
+type Challenge = RouterOutputs['event']['getEventChallengesByYear'][0] & { id?: number };
 interface Props {
   params: {
     year: string;
@@ -60,15 +60,15 @@ export default async function EventByYearLandingPage({ params }: Props) {
         </h1> */}
         <ul className="z-10 flex flex-col items-center gap-2 sm:gap-3 md:gap-4">
           {groupedDays.map((group, index) => (
-            <div key={index} className="flex gap-2 sm:gap-3 md:gap-4">
+            <div key={`row-${index}`} className="flex gap-2 sm:gap-3 md:gap-4">
               {group.map((day) => (
                 <>
                   {day.active ? (
-                    <Link key={day.id} href={`/events/${year}/${day.id}`}>
-                      <DayActive day={day.id} hasSolved={day.hasSolved} />
+                    <Link key={`day-active-${day.day}`} href={`/events/${year}/${day.day}`}>
+                      <DayActive day={day.day} hasSolved={day.hasSolved} />
                     </Link>
                   ) : (
-                    <DayInactive day={day.id} key={day.id} />
+                    <DayInactive key={`day-inactive-${day.day}`} day={day.day} />
                   )}
                 </>
               ))}

--- a/apps/aot/src/app/events/[year]/page.tsx
+++ b/apps/aot/src/app/events/[year]/page.tsx
@@ -12,7 +12,7 @@ import BgDecorations from './24BgDecorations';
 import DayInactive from './day-inactive';
 import type { RouterOutputs } from '~/trpc/react';
 
-type Challenge = RouterOutputs['event']['getEventChallengesByYear'][0] & { id?: number };
+type Challenge = RouterOutputs['event']['getEventChallengesByYear'][0];
 interface Props {
   params: {
     year: string;
@@ -37,7 +37,7 @@ export default async function EventByYearLandingPage({ params }: Props) {
   const daysThatHavePassed = activeEventChallenges.length;
 
   const inactiveEventChallenges = Array.from({ length: 25 - daysThatHavePassed }, (_, i) => ({
-    id: daysThatHavePassed + i + 1,
+    day: daysThatHavePassed + i + 1,
     hasSolved: false,
     active: false,
   })) as Challenge[];
@@ -78,7 +78,7 @@ export default async function EventByYearLandingPage({ params }: Props) {
           <div className="-mt-[4.5rem] flex">
             {lastThree.map((day, index) => (
               <div
-                key={day.id}
+                key={day.day}
                 className={`group relative h-12 w-12 cursor-pointer rounded-2xl duration-300 hover:bg-white/20 ${
                   index == 2 && 'ml-20 mr-12'
                 }`}
@@ -95,7 +95,7 @@ export default async function EventByYearLandingPage({ params }: Props) {
                   height={64}
                 />
                 <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold">
-                  {day.id}
+                  {day.day}
                 </div>
               </div>
             ))}

--- a/apps/aot/src/app/events/[year]/page.tsx
+++ b/apps/aot/src/app/events/[year]/page.tsx
@@ -77,7 +77,8 @@ export default async function EventByYearLandingPage({ params }: Props) {
 
           <div className="-mt-[4.5rem] flex">
             {lastThree.map((day, index) => (
-              <div
+              <Link
+                href={`/events/${year}/${day.day}`}
                 key={day.day}
                 className={`group relative h-12 w-12 cursor-pointer rounded-2xl duration-300 hover:bg-white/20 ${
                   index == 2 && 'ml-20 mr-12'
@@ -97,7 +98,7 @@ export default async function EventByYearLandingPage({ params }: Props) {
                 <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold">
                   {day.day}
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </ul>

--- a/apps/aot/src/server/api/routers/event.ts
+++ b/apps/aot/src/server/api/routers/event.ts
@@ -98,9 +98,10 @@ export const eventRouter = createTRPCRouter({
                 lte: currentAdventDay - 1,
               },
             },
-            include: {
+            select: {
+              orderId: true,
               challenge: {
-                include: {
+                select: {
                   submission: {
                     where: {
                       userId: ctx.session?.user?.id || '',
@@ -110,11 +111,6 @@ export const eventRouter = createTRPCRouter({
                       isSuccessful: true,
                     },
                     take: 1,
-                  },
-                  user: {
-                    select: {
-                      name: true,
-                    },
                   },
                 },
               },
@@ -127,6 +123,7 @@ export const eventRouter = createTRPCRouter({
         const { submission, ...challenge } = trackChallenge.challenge;
         return {
           ...challenge,
+          day: trackChallenge.orderId + 1,
           hasSolved: trackChallenge.challenge.submission.length > 0,
           active: true,
         };

--- a/apps/aot/src/server/api/routers/event.ts
+++ b/apps/aot/src/server/api/routers/event.ts
@@ -107,9 +107,6 @@ export const eventRouter = createTRPCRouter({
                       userId: ctx.session?.user?.id || '',
                       isSuccessful: true,
                     },
-                    select: {
-                      isSuccessful: true,
-                    },
                     take: 1,
                   },
                 },
@@ -119,14 +116,10 @@ export const eventRouter = createTRPCRouter({
         },
       });
 
-      return challenges?.trackChallenges.map((trackChallenge) => {
-        const { submission, ...challenge } = trackChallenge.challenge;
-        return {
-          ...challenge,
-          day: trackChallenge.orderId + 1,
-          hasSolved: trackChallenge.challenge.submission.length > 0,
-          active: true,
-        };
-      });
+      return challenges?.trackChallenges.map((trackChallenge) => ({
+        day: trackChallenge.orderId + 1,
+        hasSolved: trackChallenge.challenge.submission.length > 0,
+        active: true,
+      }));
     }),
 });


### PR DESCRIPTION
fixed the query so that we can get the day, previously using the id would not equal to the actual day of advent.

We can also use select in the query and it will only get what is necessary for us.


before:

```
{
aot:dev:     id: <redacted>,
aot:dev:     createdAt: 2024-10-26T20:23:40.985Z,
aot:dev:     updatedAt: 2024-11-20T01:10:41.166Z,
aot:dev:     difficulty: 'EVENT',
aot:dev:     name: '2024 Day Nine',
aot:dev:     slug: '2024-9',
aot:dev:     description: <redacted>,
aot:dev:     shortDescription: '2024 Day Nine of Advent of Typescript',
aot:dev:     code: <redacted>,
aot:dev:     tests: <redacted>,
aot:dev:     status: 'ACTIVE',
aot:dev:     tsconfig: { strict: true },
aot:dev:     userId: <redacted>,
aot:dev:     user: { name: 'TypeHero' },
aot:dev:     hasSolved: false,
aot:dev:     active: true
aot:dev:   }
```

after:

```
{ day: 25, hasSolved: false, active: true }
```
