### PR TITLE
fix(aot): make text white on light mode

### DIFF
--- a/packages/ui/src/components/year-selector.tsx
+++ b/packages/ui/src/components/year-selector.tsx
@@ -7,8 +7,8 @@ import { cn } from '../cn';
 const YEARS = ['2024', '2023'];
 
 const YEAR_COLOR_MAP: Record<string, string> = {
-  '2024': 'border-red-800 from-red-950 to-red-700',
-  '2023': 'border-emerald-800 from-emerald-700 to-emerald-900',
+  '2024': 'border-red-800 from-red-950 to-red-700 text-white',
+  '2023': 'border-emerald-800 from-emerald-700 to-emerald-900 text-white',
 };
 
 const YEAR_TO_SELECT_ITEMS_MAP: Record<string, (isLive: boolean) => JSX.Element | number> = {


### PR DESCRIPTION
This is for better visibility 

### Before
<img width="116" alt="Screenshot 2024-11-30 at 3 02 16 PM" src="https://github.com/user-attachments/assets/05dee449-2388-49b0-a63c-05c9693ade52">

### After
<img width="114" alt="Screenshot 2024-11-30 at 3 02 39 PM" src="https://github.com/user-attachments/assets/6b62a8c9-79c8-4e31-84ea-73d21993b6f5">
