### PR TITLE
fix: make leaderboard links clickable

### DIFF
--- a/apps/aot/src/app/events/(leaderboard)/_components/leaderboard-page.tsx
+++ b/apps/aot/src/app/events/(leaderboard)/_components/leaderboard-page.tsx
@@ -21,7 +21,7 @@ export function LeaderboardPage(props: {
         </div>
       </div>
       <div className="border-[hsla(0, 0%, 100%, 0.12)] relative mx-auto mt-[255px] max-w-screen-lg rounded-2xl rounded-b-none border border-b-0 bg-[hsla(0,0%,0%,0.07)] px-1 pt-1 shadow-[0px_-18px_131px_-78px_hsla(132,100%,53%,0.3)] backdrop-blur-sm md:mt-[350px] lg:mt-[500px] dark:bg-[hsla(0,0%,100%,0.07)]">
-        <div className={`${styles['ring-container']} -inset-0`}>
+        <div className={`${styles['ring-container']} -inset-0 pointer-events-none`}>
           <div className={`${styles['ring-animation']} inset-1 bg-slate-50/10`} />
         </div>
         <div className="bg-background rounded-lg rounded-b-none">

--- a/apps/aot/src/app/events/(leaderboard)/_components/leaderboard-page.tsx
+++ b/apps/aot/src/app/events/(leaderboard)/_components/leaderboard-page.tsx
@@ -21,7 +21,7 @@ export function LeaderboardPage(props: {
         </div>
       </div>
       <div className="border-[hsla(0, 0%, 100%, 0.12)] relative mx-auto mt-[255px] max-w-screen-lg rounded-2xl rounded-b-none border border-b-0 bg-[hsla(0,0%,0%,0.07)] px-1 pt-1 shadow-[0px_-18px_131px_-78px_hsla(132,100%,53%,0.3)] backdrop-blur-sm md:mt-[350px] lg:mt-[500px] dark:bg-[hsla(0,0%,100%,0.07)]">
-        <div className={`${styles['ring-container']} -inset-0 pointer-events-none`}>
+        <div className={`${styles['ring-container']} pointer-events-none -inset-0`}>
           <div className={`${styles['ring-animation']} inset-1 bg-slate-50/10`} />
         </div>
         <div className="bg-background rounded-lg rounded-b-none">


### PR DESCRIPTION
Make leaderboard links clickable

## Description
Adds `pointer-events: none` to the ring animation element so that the leaderboard that's behind it is clickable. Could probably also be fixed w/ `z-index` or `position: relative` on the leaderboard element.

Lmk if i should change what i've done!

## Related Issue
Closes #1688

## Motivation and Context
The user names seem like they should be clickable (they're links!), but you can't.

## How Has This Been Tested?
Tested by manually editing the styles in the dev tools. I couldn't install packages due to some patches not being applied :confused:.

## Screenshots/Video (if applicable):
Video from issue showing it working after adding `pointer-events: none`:

https://github.com/user-attachments/assets/6184c72b-91f6-4bcc-a9b0-9b2602216f83


