### PR TITLE
fix: inlay not updating when switching event to event

### DIFF
--- a/packages/monaco/src/split-editor.tsx
+++ b/packages/monaco/src/split-editor.tsx
@@ -309,6 +309,13 @@ export default function SplitEditor({
     }, 1000),
   ).current;
 
+  useEffect(
+    () => () => {
+      inlayHintsRef.current?.dispose();
+    },
+    [],
+  );
+
   return (
     <div className={clsx('flex h-[calc(100%-_90px)] flex-col', className)} ref={wrapper}>
       <section


### PR DESCRIPTION
## Description

the inlayHints Provider needs to be disposed with Split editor unmounts otherwise hints linger...

## Related Issue

https://bsky.app/profile/tylur.dev/post/3lc75ea7zf22d

## Motivation and Context

it was broken

## How Has This Been Tested?

ran it locally

## Screenshots/Video (if applicable):

**Before**

![Kapture 2024-11-30 at 23 17 11](https://github.com/user-attachments/assets/8376d2d4-53be-47dc-b281-8fd96ecedebe)

**After**

![Kapture 2024-11-30 at 23 14 33](https://github.com/user-attachments/assets/cd2f8aab-2a2d-48c9-bf6d-a530ce581175)

