### PR TITLE
fix: apply padding in mobile nav for logout button

### DIFF
--- a/apps/aot/src/components/navigation/signout-link.tsx
+++ b/apps/aot/src/components/navigation/signout-link.tsx
@@ -14,7 +14,7 @@ export function SignOutLink({ className }: { className?: string }) {
   return (
     <Button
       className={clsx(
-        'h-8 justify-start bg-opacity-50 px-2 text-red-500 hover:bg-red-500/20 hover:text-red-500',
+        'h-8 justify-start bg-opacity-50 text-red-500 hover:bg-red-500/20 hover:text-red-500 [&:not(:disabled)]:px-2',
         className,
       )}
       onClick={handleSignOut}


### PR DESCRIPTION
### Before:
<img width="109" alt="Screenshot 2024-12-04 at 3 21 42 PM" src="https://github.com/user-attachments/assets/001923c0-4401-406d-bb78-6c105a215cfc">

### After:
<img width="434" alt="Screenshot 2024-12-04 at 3 17 54 PM" src="https://github.com/user-attachments/assets/92e7fac9-e9da-4ee1-b648-3d000a9b58dc">
