### PR TITLE
fix: Typo in 2023 Day 21

### DIFF
--- a/challenges/aot/2023/21/user.ts
+++ b/challenges/aot/2023/21/user.ts
@@ -7,9 +7,9 @@ type TicTacToeCell = TicTacToeChip | TicTacToeEmptyCell;
 type TicTacToeYPositions = 'top' | 'middle' | 'bottom';
 type TicTacToeXPositions = 'left' | 'center' | 'right';
 type TicTacToePositions = `${TicTacToeYPositions}-${TicTacToeXPositions}`;
-type TicTactToeBoard = TicTacToeCell[][];
+type TicTacToeBoard = TicTacToeCell[][];
 type TicTacToeGame = {
-  board: TicTactToeBoard;
+  board: TicTacToeBoard;
   state: TicTacToeState;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Yeah, I'm a bit slow and still working on last year's challenges... Anyway, there's a small typo in 2023 Day 21 and this PR fixes it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1702 

## Motivation and Context

To remove a typo.

## How Has This Been Tested?

This is directly in the challenge contents, not related to the website. I'm not aware of further tests required. Let me know if I missed anything.

## Screenshots/Video (if applicable):
