### PR TITLE
fixes explore cards width overflow

### DIFF
--- a/apps/aot/src/utils/default-avatar.tsx
+++ b/apps/aot/src/utils/default-avatar.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 
+// million-ignore
 export function DefaultAvatar(props: ComponentProps<'svg'>) {
   return (
     <svg

--- a/apps/web/src/app/(profile)/[username]/completed/_components/challenges.tsx
+++ b/apps/web/src/app/(profile)/[username]/completed/_components/challenges.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { useState } from 'react';
-import { ExploreCard, type ExploreCardProps } from '~/app/explore/_components/explore-card';
+import { cn } from '@repo/ui/cn';
 import { Alert, AlertDescription, AlertTitle } from '@repo/ui/components/alert';
 import { Button } from '@repo/ui/components/button';
 import Link from 'next/link';
+import { useState } from 'react';
+import { ExploreCard, type ExploreCardProps } from '~/app/explore/_components/explore-card';
 import { DIFFICULTY_COLOR_MAP, FilterBar, type FilterOptions } from './filter-bar';
-import { cn } from '@repo/ui/cn';
 
 export function Challenges(props: {
   challenges: (ExploreCardProps['challenge'] & { id: number; slug: string })[];
@@ -58,7 +58,7 @@ export function Challenges(props: {
             }
             key={c.id}
           >
-            <ExploreCard challenge={c} className="min-w-fit xl:min-w-fit" />
+            <ExploreCard challenge={c} />
           </Link>
         ))}
       </div>

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import * as React from 'react';
-import type { ComponentProps } from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import type { ComponentProps } from 'react';
+import * as React from 'react';
 import { cn } from '../cn';
 
 const Avatar = React.forwardRef<
@@ -44,6 +44,7 @@ const AvatarFallback = React.forwardRef<
 ));
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
+// million-ignore
 function DefaultAvatar(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -77,4 +78,4 @@ function DefaultAvatar(props: ComponentProps<'svg'>) {
   );
 }
 
-export { Avatar, AvatarImage, AvatarFallback, DefaultAvatar };
+export { Avatar, AvatarFallback, AvatarImage, DefaultAvatar };

--- a/packages/ui/src/components/default-avatar.tsx
+++ b/packages/ui/src/components/default-avatar.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 
+// million-ignore
 export function DefaultAvatar(props: ComponentProps<'svg'>) {
   return (
     <svg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The width of explore cards is overflowing on the "completed" page of your profile.
This PR fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested this locally on various device viewports -- seems okay!

## Screenshots/Video (if applicable):

the issue:
<img width="1324" alt="Screenshot 2024-12-13 at 1 14 03 PM" src="https://github.com/user-attachments/assets/9af6b23d-7235-4efc-9e07-de677297b656" />

after the fix:
<img width="1303" alt="Screenshot 2024-12-13 at 1 15 05 PM" src="https://github.com/user-attachments/assets/72989586-9c21-4bea-9771-c2949de7a1cc" />

cc: @bautistaaa 
