### PR TITLE
do not query event challenges in completed section

### DIFF
--- a/apps/web/src/app/(profile)/[username]/completed/page.tsx
+++ b/apps/web/src/app/(profile)/[username]/completed/page.tsx
@@ -1,9 +1,9 @@
 import { prisma } from '@repo/db';
-import { Challenges } from './_components/challenges';
+import { Alert, AlertDescription, AlertTitle } from '@repo/ui/components/alert';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { auth } from '~/server/auth';
-import { AlertTitle, Alert, AlertDescription } from '@repo/ui/components/alert';
-import Link from 'next/link';
+import { Challenges } from './_components/challenges';
 
 export default async function CompletedPage(props: { params: { username: string } }) {
   const [, username] = decodeURIComponent(props.params.username).split('@');
@@ -73,7 +73,7 @@ export default async function CompletedPage(props: { params: { username: string 
           </AlertTitle>
           {isOwnProfile ? (
             <AlertDescription className="flex justify-center">
-              <Link className="text-primary underline-offset-4 hover:underline" href="./explore">
+              <Link className="text-primary underline-offset-4 hover:underline" href="/explore">
                 Get started with your first challenge
               </Link>
             </AlertDescription>

--- a/apps/web/src/app/(profile)/[username]/completed/page.tsx
+++ b/apps/web/src/app/(profile)/[username]/completed/page.tsx
@@ -50,6 +50,9 @@ export default async function CompletedPage(props: { params: { username: string 
           },
         },
       },
+      difficulty: {
+        not: 'EVENT',
+      },
     },
   });
   const session = await auth();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, we can see event challenges which users have solved in the *completed* section. This is not intended. 
This PR modifies the page query to not include these type of challenges on the page.

`+` This PR also fixes a minor navigation issue on production.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1706 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested this by locally modifying challenge type as "EVENT" and ensuring if the db query filters out the challenge from completed section.

## Screenshots/Video (if applicable):
N/A

cc: @bautistaaa 