### PR TITLE
style: Remove pink blur and apply green for Learners section in explore page

### DIFF
--- a/apps/web/src/app/explore/_components/explore-section.tsx
+++ b/apps/web/src/app/explore/_components/explore-section.tsx
@@ -100,7 +100,7 @@ export async function ExploreSection({ title, tag, redirectRoute }: SectionProps
         <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
           <h2 className={`relative text-3xl font-bold tracking-tight ${TITLES_BY_TAG[tag]}`}>
             <div
-              className={`absolute -left-8 -z-10 h-12 w-32 rounded-full bg-pink-300/50 blur-3xl ${COLORS_BY_TAGS[tag]}`}
+              className={`absolute -left-8 -z-10 h-12 w-32 rounded-full blur-3xl ${COLORS_BY_TAGS[tag]}`}
             />
             {title}
           </h2>


### PR DESCRIPTION
## Description
I fixed the issue where the title background color of the Learners section appeared pink instead of green on the `/explore` page route.

Please see the screenshot below.

## Related Issue

Closes #1721 

## How Has This Been Tested?

After testing on all browsers, the green background works as expected.

## Screenshots/Video (if applicable):

### Before
<img width="460" alt="Screenshot 2025-01-11 at 11 12 11 PM" src="https://github.com/user-attachments/assets/31a28a99-766d-4f20-8c8f-4f3bab50d186" />

### After
<img width="428" alt="Screenshot 2025-01-11 at 11 11 54 PM" src="https://github.com/user-attachments/assets/551a8f93-1751-4c98-b7d3-f133e138bd1c" />
