### PR TITLE
chore: remove aot ending message

### DIFF
--- a/apps/aot/src/components/DailyCountdownTimer.tsx
+++ b/apps/aot/src/components/DailyCountdownTimer.tsx
@@ -1,5 +1,4 @@
 import { DailyCountdownTimerClientComponent } from './CountdownTimer';
-import Image from 'next/image';
 
 export const DailyCountdownTimer = () => {
   const nowDate = Date.now();

--- a/apps/aot/src/components/DailyCountdownTimer.tsx
+++ b/apps/aot/src/components/DailyCountdownTimer.tsx
@@ -8,14 +8,7 @@ export const DailyCountdownTimer = () => {
 
   // This will render one day after the last challenge is released
   if (isAtLeastOneDayPastAotEndDate) {
-    return (
-      <>
-        <p className="text-center text-xl font-semibold">Thats a wrap! See you next year!</p>
-        <p className="text-center text-xl font-semibold">
-          <Image src="/santa_dead.png" width={200} height={200} alt="" className="" />
-        </p>
-      </>
-    );
+    return null;
   }
 
   return <DailyCountdownTimerClientComponent />;


### PR DESCRIPTION
It looks dumb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the farewell message and image that appeared after December 26, 2024. The timer will now simply disappear after this date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->