### PR TITLE
Add cron job for Vercel

### DIFF
--- a/apps/web/src/app/api/cron/update-ported-challenges/route.ts
+++ b/apps/web/src/app/api/cron/update-ported-challenges/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Vercel Cron Job: Update Ported Challenges
+ * 
+ * This API route is designed to be called by Vercel's cron job scheduler
+ * to automatically run the update-ported-challenges script on a schedule.
+ * 
+ * Path: /api/cron/update-ported-challenges
+ * Method: GET
+ * Authentication: Bearer token via CRON_SECRET environment variable
+ * 
+ * Related to GitHub Issue: #1701
+ */
+
+// Force dynamic rendering to ensure this runs as a server-side function
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  // Verify this request is coming from Vercel cron
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  
+  if (!cronSecret) {
+    console.error('CRON_SECRET environment variable is not set');
+    return NextResponse.json(
+      { error: 'Cron configuration error' }, 
+      { status: 500 }
+    );
+  }
+  
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    console.warn('Unauthorized cron request attempt');
+    return NextResponse.json(
+      { error: 'Unauthorized' }, 
+      { status: 401 }
+    );
+  }
+
+  const startTime = Date.now();
+  
+  try {
+    console.log('Starting update-ported-challenges cron job...');
+    
+    // Import and execute the update script
+    // Note: The script is a top-level execution, so we import it to trigger execution
+    await import('../../../../../../../packages/db/temp/update-ported-challenges');
+    
+    const executionTime = Date.now() - startTime;
+    
+    console.log(`update-ported-challenges completed successfully in ${executionTime}ms`);
+    
+    return NextResponse.json({ 
+      success: true, 
+      message: 'Update ported challenges completed successfully',
+      timestamp: new Date().toISOString(),
+      executionTimeMs: executionTime
+    });
+    
+  } catch (error) {
+    const executionTime = Date.now() - startTime;
+    
+    console.error('update-ported-challenges cron job failed:', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+      executionTimeMs: executionTime
+    });
+    
+    return NextResponse.json({ 
+      success: false,
+      error: 'Cron job execution failed',
+      message: error instanceof Error ? error.message : 'Unknown error occurred',
+      timestamp: new Date().toISOString(),
+      executionTimeMs: executionTime
+    }, { status: 500 });
+  }
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -10,6 +10,10 @@
     {
       "path": "/api/cron/sync-contributors",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/update-ported-challenges",
+      "schedule": "0 2 * * *"
     }
   ]
 }

--- a/docs/cron-update-ported-challenges.md
+++ b/docs/cron-update-ported-challenges.md
@@ -1,0 +1,128 @@
+# Update Ported Challenges Cron Job
+
+This document describes the implementation of a Vercel cron job to automatically run the `update-ported-challenges.ts` script on a schedule.
+
+## Overview
+
+**Issue**: [#1701](https://github.com/typehero/typehero/issues/1701)  
+**Purpose**: Automate the execution of the update-ported-challenges script  
+**Schedule**: Daily at 2:00 AM UTC  
+**Path**: `/api/cron/update-ported-challenges`
+
+## Implementation
+
+### Files Added/Modified
+
+1. **New API Route**: `apps/web/src/app/api/cron/update-ported-challenges/route.ts`
+   - Secure endpoint with Bearer token authentication
+   - Imports and executes the update script
+   - Comprehensive error handling and logging
+
+2. **Updated Configuration**: `apps/web/vercel.json`
+   - Added new cron job configuration
+   - Schedule: `"0 2 * * *"` (daily at 2 AM UTC)
+
+### Security
+
+The cron job is secured using the `CRON_SECRET` environment variable:
+
+1. **Generate Secret**:
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Set Environment Variable**:
+   Add `CRON_SECRET` to your Vercel project environment variables with the generated value.
+
+3. **Authentication**:
+   Vercel automatically includes the secret as a Bearer token in the `Authorization` header when invoking the cron job.
+
+### Script Execution
+
+The cron job imports the existing script at:
+```
+packages/db/temp/update-ported-challenges.ts
+```
+
+The script runs automatically when imported due to its top-level execution structure.
+
+## Testing
+
+### Local Testing
+```bash
+# Set CRON_SECRET in .env.local
+echo "CRON_SECRET=your_generated_secret_here" >> .env.local
+
+# Test the endpoint
+curl -H "Authorization: Bearer your_generated_secret_here" \
+  http://localhost:3000/api/cron/update-ported-challenges
+```
+
+### Production Testing
+1. Navigate to Vercel Dashboard → Project Settings → Cron Jobs
+2. Find the "update-ported-challenges" cron job
+3. Click "Run" to manually trigger execution
+4. Check logs for execution results
+
+## Monitoring
+
+### Logs
+- **Function Logs**: Available in Vercel Dashboard → Functions tab
+- **Cron Job Logs**: Available in Vercel Dashboard → Settings → Cron Jobs → View Logs
+- **Console Output**: All execution details are logged to console
+
+### Expected Responses
+- **Success**: HTTP 200 with execution time and timestamp
+- **Unauthorized**: HTTP 401 if CRON_SECRET is missing or incorrect
+- **Error**: HTTP 500 with error details and execution time
+
+## Schedule
+
+**Current**: `"0 2 * * *"` (Daily at 2:00 AM UTC)
+
+### Alternative Schedules
+- Every 6 hours: `"0 */6 * * *"`
+- Weekly (Sunday): `"0 2 * * 0"`
+- Weekdays only: `"0 2 * * 1-5"`
+
+## Environment Variables Required
+
+- `CRON_SECRET`: Secure random string (minimum 16 characters recommended)
+
+## Related Files
+
+- **Script**: `packages/db/temp/update-ported-challenges.ts`
+- **Example Cron Jobs**: `apps/web/src/app/api/cron/short-url-cleanup/route.ts`
+- **Configuration**: `apps/web/vercel.json`
+
+## Troubleshooting
+
+### Common Issues
+
+1. **401 Unauthorized**
+   - Verify `CRON_SECRET` is set in Vercel environment variables
+   - Ensure the secret matches what's being sent
+
+2. **Import Errors**
+   - Check that the relative path to the script is correct
+   - Verify all dependencies are available in the web app context
+
+3. **Execution Timeout**
+   - Monitor execution time in logs
+   - Consider breaking up long-running operations
+
+### Debugging
+
+1. **Check Logs**: Use Vercel Dashboard → Functions → View Logs
+2. **Manual Testing**: Use the "Run" button in Cron Jobs settings
+3. **Local Testing**: Test the endpoint locally with proper authentication
+
+## Deployment
+
+This cron job will be automatically deployed with the next production deployment. Vercel will:
+
+1. Parse the `vercel.json` configuration
+2. Set up the scheduled execution
+3. Provide the cron job interface in the dashboard
+
+No additional deployment steps are required beyond merging this PR and deploying to production.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces a Vercel cron job to automate the execution of the `update-ported-challenges.ts` script.
- A new API route (`apps/web/src/app/api/cron/update-ported-challenges/route.ts`) is created to serve as the cron endpoint, secured with a `CRON_SECRET`.
- The `apps/web/vercel.json` configuration is updated to schedule this cron job to run daily at 2 AM UTC.
- Comprehensive documentation (`docs/cron-update-ported-challenges.md`) is added, detailing setup, security, testing, and troubleshooting.

## Related Issue
Closes #1701

## Motivation and Context
This change automates the process of updating ported challenges, as requested in issue #1701. Automating this script ensures that the challenges data remains up-to-date without manual intervention, improving data consistency and reducing operational overhead.

## How Has This Been Tested?
- **Local Testing**: The API route was tested locally using `curl` with a mock `CRON_SECRET` to verify authentication and script execution.
- **Manual Trigger (Vercel)**: The cron job can be manually triggered from the Vercel dashboard to observe its behavior and logs in a deployed environment.

## Screenshots/Video (if applicable):
N/A