### PR TITLE
require indexed access type solution

### DIFF
--- a/challenges/default-generic-arguments/tests.ts
+++ b/challenges/default-generic-arguments/tests.ts
@@ -15,3 +15,7 @@ type test_TSConfig_true = Expect<Equal<TSConfig<{ strict: true }>, { strict: tru
 type test_TSConfig_false = Expect<Equal<TSConfig<{ strict: false }>, { strict: false }>>;
 
 type test_TSConfig_boolean = Expect<Equal<TSConfig<{ strict: boolean }>, { strict: boolean }>>;
+
+type test_TSConfig_disallows_widening = Expect<
+  Equal<TSConfig<{ strict: false; extra: 123 }>, { strict: false }>
+>;


### PR DESCRIPTION
This will prevent a solution where the user doesn't use an indexed access type.

## Description
The following passes existing tests, but defeats the purpose of the challenge.
```typescript
type TSConfig<T extends { strict: boolean } = { strict: true }> = T;
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I created a reproduction repo locally using the type-tester package.

## Screenshots/Video (if applicable):

<img width="696" height="744" alt="image" src="https://github.com/user-attachments/assets/1541ca0f-55a0-4697-a312-eab487ed8366" />
<img width="691" height="753" alt="image" src="https://github.com/user-attachments/assets/c66959ba-5717-4c07-be8f-a85c3cbdf56d" />
<img width="658" height="750" alt="image" src="https://github.com/user-attachments/assets/9224fd13-04cc-44f7-92a3-aa7692ae580b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify type narrowing behavior for configuration objects, ensuring only relevant properties are retained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->