### PR TITLE
feat: add back button to challenge page tab bar

### DIFF
--- a/apps/web/src/app/challenge/[slug]/left-wrapper.tsx
+++ b/apps/web/src/app/challenge/[slug]/left-wrapper.tsx
@@ -8,7 +8,7 @@ import { FeatureFlagContext } from '~/app/feature-flag-provider';
 
 import { cn } from '@repo/ui/cn';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@repo/ui/components/tabs';
-import { FlaskConical, History, Text } from '@repo/ui/icons';
+import { ArrowLeft, FlaskConical, History, Text } from '@repo/ui/icons';
 
 import type { ChallengeRouteData } from './getChallengeRouteData';
 import { useTrackNavigationVisiblity } from './use-track-visibility.hook';
@@ -136,19 +136,33 @@ export function LeftWrapper({
           className={cn(
             'bg-background/90 dark:bg-muted/90 sticky top-0 grid h-auto w-full border-b border-zinc-300 backdrop-blur-sm dark:border-zinc-700',
             {
-              'grid-rows-3 gap-2': isIconOnly,
-              'grid-cols-3 gap-0.5': !isIconOnly,
+              'grid-rows-4 gap-2': isIconOnly,
+              'grid-cols-[auto_1fr_1fr_1fr] gap-0.5': !isIconOnly,
               'rounded-tl-xl': !isTrackVisible,
             },
           )}
           ref={tabsListRef}
         >
+          <button
+            type="button"
+            title="Go back"
+            aria-label="Go back"
+            className={cn(
+              'flex items-center justify-center rounded-md px-2 duration-300 hover:bg-neutral-200/50 dark:hover:bg-neutral-700/50',
+              {
+                'p-4': isIconOnly,
+                'rounded-tl-xl': !isTrackVisible,
+              },
+            )}
+            onClick={() => router.back()}
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
           <TabsTrigger
             className={cn(
               'rounded-md duration-300 hover:bg-neutral-200/50 data-[state=active]:bg-neutral-200 dark:hover:bg-neutral-700/50 dark:data-[state=active]:bg-neutral-700',
               {
                 'p-4': isIconOnly,
-                'rounded-tl-xl': !isTrackVisible,
                 'rounded-bl-xl': isCollapsed && !isDesktop,
               },
             )}


### PR DESCRIPTION
## What

Adds a back button (`←`) as the first item in the Description / Solutions / Submissions tab bar on the challenge page. Clicking it calls `router.back()`, returning the user to wherever they came from (explore list, track page, direct link, etc.).

## Why

Users switching between challenges had no in-page way to go back — the only option was re-clicking "Explore" in the top nav or using the browser back button, which isn't obvious.

## How

- Added `ArrowLeft` to the existing icons import in `left-wrapper.tsx`
- Expanded the `TabsList` grid from 3 slots to 4:
  - Normal mode: `grid-cols-3` → `grid-cols-[auto_1fr_1fr_1fr]` (back button takes its natural width, tabs share the rest equally)
  - Icon-only / collapsed desktop: `grid-rows-3` → `grid-rows-4`
- Back button inherits the same hover styles as the tab triggers and takes the `rounded-tl-xl` corner that previously belonged to the Description tab

## Test plan

- [ ] Navigate to any challenge from `/explore` — back button appears in the tab bar
- [ ] Click back button — returns to `/explore`
- [ ] Navigate to a challenge from a track — back button returns to the track page
- [ ] Collapse the left panel (desktop) — back button appears as the first icon in the stacked icon-only view
- [ ] Collapse the left panel (mobile) — back button is visible and functional
- [ ] Check dark mode — hover/active states look correct

Closes #1335

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add back button to challenge page tab bar
> Adds a back button with an `ArrowLeft` icon as the first item in the `LeftWrapper` tab bar, which calls `router.back()` on click. The tab grid layout is updated to accommodate the new leading column, and top-left corner rounding is moved from the first `TabsTrigger` to the new back button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6a9065.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Go back" button to the challenge page tabs header, enabling users to easily return to the previous screen.

* **Style**
  * Updated the tabs header layout and spacing to accommodate the new back button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->