### PR TITLE
test: add GITHUB_AOT_* to turbo globalEnv

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.com/schema.v2.json",
-  "globalEnv": ["DATABASE_URL", "NEXT_RUNTIME"],
+  "globalEnv": ["DATABASE_URL", "NEXT_RUNTIME", "GITHUB_AOT_ID", "GITHUB_AOT_SECRET"],
   "globalDependencies": [".env", ".env.*"],
   "tasks": {
     "build": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Temporary test change: add `GITHUB_AOT_ID` and `GITHUB_AOT_SECRET` to root `turbo.json` `globalEnv` so every Turborepo task (including `@repo/db#db:generate`) receives them.

This is to validate whether the Vercel Turbo “missing from turbo.json” warning for those vars under `db:generate` is related to the runtime `No GITHUB_AOT_ID has been provided` error. These vars were already listed under the `build` task `env` array.

**How to test:** merge/deploy this branch (or deploy the preview) on the AOT Vercel project and see if the auth error goes away.

**Expectation:** if the error is from client-side evaluation of `auth.ts` (where non-`NEXT_PUBLIC_` secrets are always undefined), this will not fix it. If it does fix it, Turbo task env scoping was the issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97be5869-44c1-4997-9787-94b52a7b5943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97be5869-44c1-4997-9787-94b52a7b5943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `GITHUB_AOT_ID` and `GITHUB_AOT_SECRET` to Turborepo global env
> Adds `GITHUB_AOT_ID` and `GITHUB_AOT_SECRET` to the `globalEnv` array in [turbo.json](https://github.com/typehero/typehero/pull/1770/files#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3), making them available to all Turborepo tasks alongside the existing `DATABASE_URL` and `NEXT_RUNTIME` variables.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b130bb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime configuration to recognize additional authentication, search, payment, and application environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->