### PR TITLE
fix(aot): keep GITHUB_AOT_* auth config off the client bundle

### DIFF
--- a/apps/aot/src/app/events/[year]/[day]/_components/types.ts
+++ b/apps/aot/src/app/events/[year]/[day]/_components/types.ts
@@ -1,4 +1,4 @@
 import type { inferRouterOutputs } from '@trpc/server';
-import type { AppRouter } from '~/server/api/root';
+import type { AppRouter } from '~/trpc/router-type';
 
 export type Challenge = inferRouterOutputs<AppRouter>['event']['getEventChallengeBySlug'];

--- a/apps/aot/src/server/api/root.ts
+++ b/apps/aot/src/server/api/root.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { createCallerFactory, createTRPCRouter } from '~/server/api/trpc';
 import { eventRouter } from './routers/event';
 

--- a/apps/aot/src/server/api/trpc.ts
+++ b/apps/aot/src/server/api/trpc.ts
@@ -7,6 +7,8 @@
  * need to use are documented accordingly near the end.
  */
 
+import 'server-only';
+
 import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import { ZodError } from 'zod';

--- a/apps/aot/src/server/auth.ts
+++ b/apps/aot/src/server/auth.ts
@@ -1,18 +1,23 @@
+import 'server-only';
+
 import NextAuth from '@repo/auth/next-auth';
 
 import { baseNextAuthConfig, createGitHubProvider } from '@repo/auth/server';
 
-if (!process.env.GITHUB_AOT_ID) {
+const githubId = process.env.GITHUB_AOT_ID;
+const githubSecret = process.env.GITHUB_AOT_SECRET;
+
+if (!githubId) {
   throw new Error('No GITHUB_AOT_ID has been provided.');
 }
 
-if (!process.env.GITHUB_AOT_SECRET) {
+if (!githubSecret) {
   throw new Error('No GITHUB_AOT_SECRET has been provided.');
 }
 
 export const authOptions = {
   ...baseNextAuthConfig,
-  providers: [createGitHubProvider(process.env.GITHUB_AOT_ID, process.env.GITHUB_AOT_SECRET)],
+  providers: [createGitHubProvider(githubId, githubSecret)],
 };
 
 export const { handlers, auth } = NextAuth(authOptions);

--- a/apps/aot/src/trpc/react.tsx
+++ b/apps/aot/src/trpc/react.tsx
@@ -8,7 +8,7 @@ import { type inferRouterInputs, type inferRouterOutputs } from '@trpc/server';
 import { useState } from 'react';
 import { default as SuperJSON } from 'superjson';
 
-import { type AppRouter } from '~/server/api/root';
+import type { AppRouter } from './router-type';
 import { createQueryClient } from './query-client';
 
 let clientQueryClientSingleton: QueryClient | undefined;

--- a/apps/aot/src/trpc/router-type.ts
+++ b/apps/aot/src/trpc/router-type.ts
@@ -1,0 +1,6 @@
+/**
+ * Type-only re-export so client code can reference AppRouter without
+ * pulling the server router module graph (auth, prisma, etc.) into the
+ * browser bundle. Use `import type` / `export type` only.
+ */
+export type { AppRouter } from '~/server/api/root';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `No GITHUB_AOT_ID has been provided` error in the browser was **not** a missing Vercel/Turbo env var. Next.js 16 / Turbopack was bundling `~/server/auth` into the **client** via:

`providers.tsx` → `trpc/react.tsx` → `server/api/root` → `server/api/trpc` → `server/auth`

`GITHUB_AOT_ID` is a server secret (not `NEXT_PUBLIC_*`), so it is always `undefined` in the browser and the top-level check threw on module evaluation. That matches the minified client code (`y.default.env.GITHUB_AOT_ID`).

The earlier `globalEnv` experiment (#1770) correctly did not fix this.

## Fix

- Mark `auth.ts`, `trpc.ts`, and `root.ts` with `import 'server-only'`
- Introduce `trpc/router-type.ts` (type-only re-export) for client `AppRouter` imports so the server router graph stays off the client

## Verification

Local `next build` with `server-only` on auth previously failed with an explicit client import trace through `trpc/react.tsx`. After this change, that leak is gone and `GITHUB_AOT_ID` only appears in server chunks, not `.next/static`.

Deploy this branch on the AOT Vercel project to confirm the browser error is gone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97be5869-44c1-4997-9787-94b52a7b5943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97be5869-44c1-4997-9787-94b52a7b5943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `GITHUB_AOT_*` auth config out of the client bundle in the AOT app
> - Adds `server-only` imports to [auth.ts](https://github.com/typehero/typehero/pull/1772/files#diff-c68652180587bca15dcd38ec6bb7d9e80005ed5603849564e06f1e976ac97265), [trpc.ts](https://github.com/typehero/typehero/pull/1772/files#diff-bcb30d31edae899691498bb96e5522e758b70049c81a8c11b4903a51bf313bd4), and [root.ts](https://github.com/typehero/typehero/pull/1772/files#diff-76b0ef10f991923f3a1157ff55dc1e5bfa7e99e4f7eec1afe34b83abb4281d9b) to prevent these modules from being included in the client bundle.
> - Introduces [router-type.ts](https://github.com/typehero/typehero/pull/1772/files#diff-e57defa2b8a4c8d164bb191778bc7a42603c8f25461d81872838fb1b7b19fc4b) as a type-only re-export of `AppRouter`, so client-side code can reference the router type without importing the server module.
> - Updates `AppRouter` imports in [react.tsx](https://github.com/typehero/typehero/pull/1772/files#diff-0a254a24336f4996fa9e863ea56405ece57e673f63f2258447f7825991c47d8f) and [types.ts](https://github.com/typehero/typehero/pull/1772/files#diff-e02501f6c9d2b2657ebbee06a3a173dea653b1078cee889c3b795c556803db84) to use the new type-only re-export.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e962f88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->